### PR TITLE
Always skip installing local dependencies when using `unidep install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,7 @@ options:
                         package to skip. For example, use `--skip-dependency
                         pandas` to skip installing pandas.
   --no-dependencies     Skip installing dependencies from `requirements.yaml`
-                        file(s) and only install local package(s). This passes
-                        the `--no-dependencies` flag to `pip install`. Useful
+                        file(s) and only install local package(s). Useful
                         after installing a `conda-lock.yml` file because then
                         all dependencies have already been installed.
   --conda-executable {conda,mamba,micromamba}
@@ -509,8 +508,7 @@ options:
                         package to skip. For example, use `--skip-dependency
                         pandas` to skip installing pandas.
   --no-dependencies     Skip installing dependencies from `requirements.yaml`
-                        file(s) and only install local package(s). This passes
-                        the `--no-dependencies` flag to `pip install`. Useful
+                        file(s) and only install local package(s). Useful
                         after installing a `conda-lock.yml` file because then
                         all dependencies have already been installed.
   --conda-executable {conda,mamba,micromamba}

--- a/example/README.md
+++ b/example/README.md
@@ -89,7 +89,7 @@ Just run `unidep install ./setup_py_project` or `unidep install -e ./setup_py_pr
 
 📝 Found local dependencies: {'setup_py_project': ['hatch_project', 'setuptools_project']}
 
-📦 Installing project with `/opt/hostedtoolcache/Python/3.12.1/x64/bin/python -m pip install -e /home/runner/work/unidep/unidep/example/hatch_project -e /home/runner/work/unidep/unidep/example/setuptools_project -e ./setup_py_project`
+📦 Installing project with `/opt/hostedtoolcache/Python/3.12.1/x64/bin/python -m pip install --no-dependencies -e /home/runner/work/unidep/unidep/example/hatch_project -e /home/runner/work/unidep/unidep/example/setuptools_project -e ./setup_py_project`
 
 ```
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -71,7 +72,7 @@ def test_install_all_command(capsys: pytest.CaptureFixture) -> None:
     assert "Installing conda dependencies" in captured.out
     assert "Installing pip dependencies" in captured.out
     assert (
-        f"pip install -e {REPO_ROOT}/example/hatch_project -e {REPO_ROOT}/example/setup_py_project -e {REPO_ROOT}/example/setuptools_project`"
+        f"pip install --no-dependencies -e {REPO_ROOT}/example/hatch_project -e {REPO_ROOT}/example/setup_py_project -e {REPO_ROOT}/example/setuptools_project`"
         in captured.out
     )
 
@@ -100,10 +101,20 @@ def test_unidep_install_all_dry_run() -> None:
 
     # Check the output
     assert result.returncode == 0, "Command failed to execute successfully"
-    assert "📦 Installing pip dependencies with" in result.stdout
-    assert "📦 Installing project with" in result.stdout
     assert (
-        f"-m pip install -e {REPO_ROOT}/example/hatch_project -e {REPO_ROOT}/example/setup_py_project -e {REPO_ROOT}/example/setuptools_project`"
+        '📦 Installing conda dependencies with `micromamba install --yes --override-channels --channel conda-forge pandas adaptive">=1.0.0, <2.0.0" pfapack pipefunc`'
+        in result.stdout
+    )
+    assert (
+        f"📦 Installing pip dependencies with `{sys.executable} -m pip install unidep rsync-time-machine slurm-usage fileup codestructure aiokef markdown-code-runner home-assistant-streamdeck-yaml`"
+        in result.stdout
+    )
+    assert (
+        "📝 Found local dependencies: {'setup_py_project': ['hatch_project', 'setuptools_project'], 'setuptools_project': ['hatch_project']}"
+        in result.stdout
+    )
+    assert (
+        f"📦 Installing project with `{sys.executable} -m pip install --no-dependencies -e {REPO_ROOT}/example/hatch_project -e {REPO_ROOT}/example/setup_py_project -e {REPO_ROOT}/example/setuptools_project`"
         in result.stdout
     )
 

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -156,8 +156,7 @@ def _add_common_args(  # noqa: PLR0912
             "--no-dependencies",
             action="store_true",
             help="Skip installing dependencies from `requirements.yaml`"
-            " file(s) and only install local package(s). This passes the"
-            " `--no-dependencies` flag to `pip install`. Useful after"
+            " file(s) and only install local package(s). Useful after"
             " installing a `conda-lock.yml` file because then all"
             " dependencies have already been installed.",
         )
@@ -647,9 +646,7 @@ def _install_command(  # noqa: PLR0912
             if dep.resolve() not in installable_set
         ]
         if installable:
-            pip_flags = []
-            if no_dependencies:
-                pip_flags.append("--no-dependencies")
+            pip_flags = ["--no-dependencies"]  # we just ran pip/conda install, so skip
             if verbose:
                 pip_flags.append("--verbose")
 


### PR DESCRIPTION
This is because we just run `pip install` and `conda install` before calling `pip install /local/package`.