### PR TITLE
Allow installing local packages not managed by unidep

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ dependencies:
 local_dependencies:
   - ../other-project-using-unidep  # include other projects that use unidep
   - ../common-requirements.yaml  # include other requirements.yaml files
+  - ../project-not-managed-by-unidep  # 🚨 Skips its dependencies!
 platforms:  # (Optional) specify platforms that are supported (used in conda-lock)
   - linux-64
   - osx-arm64
@@ -141,8 +142,9 @@ dependencies = [
     { conda = "cuda-toolkit =11.8:linux64" }         # Use platform selectors by appending `:linux64`
 ]
 local_dependencies = [
-    "../other-project-using-unidep", # include other projects that use unidep
-    "../common-requirements.yaml"    # include other requirements.yaml files
+    "../other-project-using-unidep",   # include other projects that use unidep
+    "../common-requirements.yaml"      # include other requirements.yaml files
+    "../project-not-managed-by-unidep" # 🚨 Skips its dependencies!
 ]
 platforms = [ # (Optional) specify platforms that are supported (used in conda-lock)
     "linux-64",
@@ -167,7 +169,7 @@ See [Build System Integration](#jigsaw-build-system-integration) for more inform
 - Use `conda:` to specify packages that are only available through Conda.
 - Use `# [selector]` (YAML only) or `package:selector` to specify platform-specific dependencies.
 - Use `platforms:` to specify the platforms that are supported.
-- Use `local_dependencies:` to include other `requirements.yaml` or `pyproject.toml` files and merge them into one.
+- Use `local_dependencies:` to include other `requirements.yaml` or `pyproject.toml` files and merge them into one. Also allows projects that are not managed by `unidep` to be included, but be aware that this skips their dependencies!
 
 > *We use the YAML notation here, but the same information can be specified in `pyproject.toml` as well.*
 

--- a/tests/test_parse_yaml_local_dependencies.py
+++ b/tests/test_parse_yaml_local_dependencies.py
@@ -382,3 +382,24 @@ def test_parse_local_dependencies_pip_installable_with_non_installable_project(
             example_folder / "setup_py_project",
         ],
     }
+
+
+def test_local_non_unidep_managed_dependency(tmp_path: Path) -> None:
+    project1 = tmp_path / "project1"
+    project1.mkdir(exist_ok=True, parents=True)
+    project2 = tmp_path / "project2"
+    project2.mkdir(exist_ok=True, parents=True)
+    r1 = project1 / "requirements.yaml"
+    r1.write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+                - ../project2  # is not managed by unidep
+            """,
+        ),
+    )
+    r2 = project2 / "setup.py"  # not managed by unidep
+    r2.touch()
+    with pytest.warns(UserWarning, match="not managed by unidep"):
+        data = parse_local_dependencies(r1, verbose=False, check_pip_installable=False)
+    assert data == {project1.resolve(): [project2.resolve()]}

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -306,10 +306,13 @@ def _extract_local_dependencies(
             # Means that this is a local package that is not managed by unidep.
             if is_pip_installable(abs_include):
                 dependencies[str(base_path)].add(str(abs_include))
-                # TODO[Bas]: right now this will install the local dependency
-                # however, it will use `--no-dependencies` which is wrong!
-                # Maybe we need to deal with these local dependencies in a
-                # different way?
+                warn(
+                    f"⚠️ Installing a local dependency (`{abs_include.name}`) which is"
+                    " not managed by unidep, this will skip all of its dependencies,"
+                    " i.e., it will call `pip install` with `--no-dependencies`."
+                    " To properly manage this dependency, add a `requirements.yaml`"
+                    " or `pyproject.toml` file with `[tool.unidep]` in its directory.",
+                )
             else:
                 msg = (
                     f"`{include}` in `local_dependencies` is not pip installable nor is"

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -306,6 +306,10 @@ def _extract_local_dependencies(
             # Means that this is a local package that is not managed by unidep.
             if is_pip_installable(abs_include):
                 dependencies[str(base_path)].add(str(abs_include))
+                # TODO[Bas]: right now this will install the local dependency
+                # however, it will use `--no-dependencies` which is wrong!
+                # Maybe we need to deal with these local dependencies in a
+                # different way?
             else:
                 msg = (
                     f"`{include}` in `local_dependencies` is not pip installable nor is"

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -217,7 +217,12 @@ def parse_requirements(  # noqa: PLR0912
 
         # Handle "local_dependencies" (or old name "includes", changed in 0.42.0)
         for include in _get_local_dependencies(data):
-            requirements_path = dependencies_filename(p.parent / include).resolve()
+            try:
+                requirements_path = dependencies_filename(p.parent / include).resolve()
+            except FileNotFoundError:
+                # Means that this is a local package that is not managed by unidep.
+                # We do not need to do anything here, just in `unidep install`.
+                continue
             if requirements_path in seen:
                 continue  # Avoids circular local_dependencies
             if verbose:
@@ -291,7 +296,24 @@ def _extract_local_dependencies(
     for include in _get_local_dependencies(data):
         assert not os.path.isabs(include)  # noqa: PTH117
         abs_include = (path.parent / include).resolve()
-        requirements_path = dependencies_filename(abs_include)
+        if not abs_include.exists():
+            msg = f"File `{include}` not found."
+            raise FileNotFoundError(msg)
+
+        try:
+            requirements_path = dependencies_filename(abs_include)
+        except FileNotFoundError:
+            # Means that this is a local package that is not managed by unidep.
+            if is_pip_installable(abs_include):
+                dependencies[str(base_path)].add(str(abs_include))
+            else:
+                msg = (
+                    f"`{include}` in `local_dependencies` is not pip installable nor is"
+                    " it managed by unidep. Remove it from `local_dependencies`."
+                )
+                raise RuntimeError(msg) from None
+            continue
+
         project_path = str(requirements_path.parent)
         if project_path == str(base_path):
             continue


### PR DESCRIPTION
Closes #104

Because we cannot extract any dependencies that would also be installable with conda, we force `--no-dependencies`.

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--113.org.readthedocs.build/en/113/

<!-- readthedocs-preview unidep end -->