### PR TITLE
Fix entrypoint and prevent AttributeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 unidep = "unidep:_cli.main"
 
 [project.entry-points."setuptools.finalize_distribution_options"]
-unidep = "unidep:_setuptools_integration._setuptools_finalizer"
+unidep = "unidep._setuptools_integration:_setuptools_finalizer"
 
 [project.entry-points.hatch]
 unidep = "unidep._hatch_integration"


### PR DESCRIPTION
```
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [32 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/path/to/setup.py", line 5, in <module>
          setup(
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/dist.py", line 303, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 283, in __init__
          self.finalize_options()
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/dist.py", line 680, in finalize_options
          for ep in sorted(loaded, key=by_order):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "~/micromamba/envs/myenv/lib/python3.11/site-packages/setuptools/dist.py", line 679, in <lambda>
          loaded = map(lambda e: e.load(), filtered)
                                 ^^^^^^^^
        File "~/micromamba/envs/myenv/lib/python3.11/importlib/metadata/__init__.py", line 206, in load
          return functools.reduce(getattr, attrs, module)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'unidep' has no attribute '_setuptools_integration'
```

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview unidep end -->