### PR TITLE
Allow dot in package name, e.g., for `ruamel.yaml`

### DIFF
--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -2041,3 +2041,24 @@ def test_not_equal(tmp_path: Path) -> None:
             },
         },
     }
+
+
+def test_dot_in_package_name(tmp_path: Path) -> None:
+    p1 = tmp_path / "p1" / "requirements.yaml"
+    p1.parent.mkdir()
+    p1.write_text(
+        textwrap.dedent(
+            """\
+            dependencies:
+                - ruamel.yaml
+            """,
+        ),
+    )
+
+    requirements = parse_requirements(p1, verbose=False)
+    assert requirements.requirements == {
+        "ruamel.yaml": [
+            Spec(name="ruamel.yaml", which="conda", identifier="17e5d607"),
+            Spec(name="ruamel.yaml", which="pip", identifier="17e5d607"),
+        ],
+    }

--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -2043,7 +2043,11 @@ def test_not_equal(tmp_path: Path) -> None:
     }
 
 
-def test_dot_in_package_name(tmp_path: Path) -> None:
+@pytest.mark.parametrize("toml_or_yaml", ["toml", "yaml"])
+def test_dot_in_package_name(
+    toml_or_yaml: Literal["toml", "yaml"],
+    tmp_path: Path,
+) -> None:
     p1 = tmp_path / "p1" / "requirements.yaml"
     p1.parent.mkdir()
     p1.write_text(
@@ -2054,6 +2058,7 @@ def test_dot_in_package_name(tmp_path: Path) -> None:
             """,
         ),
     )
+    p1 = maybe_as_toml(toml_or_yaml, p1)
 
     requirements = parse_requirements(p1, verbose=False)
     assert requirements.requirements == {

--- a/unidep/utils.py
+++ b/unidep/utils.py
@@ -153,7 +153,7 @@ class ParsedPackageStr(NamedTuple):
 def parse_package_str(package_str: str) -> ParsedPackageStr:
     """Splits a string into package name, version pinning, and platform selector."""
     # Regex to match package name, version pinning, and optionally platform selector
-    name_pattern = r"[a-zA-Z0-9_-]+"
+    name_pattern = r"[a-zA-Z0-9_.-]+"  # Added dot to the character set
     version_pin_pattern = r".*?"
     selector_pattern = r"[a-z0-9\s]+"
     pattern = rf"({name_pattern})\s*({version_pin_pattern})?(:({selector_pattern}))?$"


### PR DESCRIPTION
Came up in #111.

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--137.org.readthedocs.build/en/137/

<!-- readthedocs-preview unidep end -->