### PR TITLE
Add `[tool.ruff.lint]` subsections in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ line_length = 88
 line-length = 88
 target-version = "py37"
 select = ["ALL"]
+
+[tool.ruff.lint]
 ignore = [
     "T20",     # flake8-print
     "ANN101",  # Missing type annotation for {name} in method
@@ -114,14 +116,14 @@ ignore = [
     "TD002",   # Missing author in TODO
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["SLF001", "D103", "E501", "PLR2004"]
 "tests/test_examples.py" = ["E501"]
 ".github/*" = ["INP001"]
 "example/*" = ["INP001", "D100"]
 "docs/*" = ["INP001", "E501"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 18
 
 [tool.mypy]

--- a/unidep/_conflicts.py
+++ b/unidep/_conflicts.py
@@ -178,6 +178,7 @@ def resolve_conflicts(
     Dictionary mapping package names to a dictionary of resolved metadata.
     The resolved metadata is a dictionary mapping platforms to a dictionary
     mapping sources to a single `Spec` object.
+
     """
     if platforms and not set(platforms).issubset(get_args(Platform)):
         msg = f"Invalid platform: {platforms}, must contain only {get_args(Platform)}"

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -351,6 +351,7 @@ def parse_requirements(
         `requirements.yaml` or `pyproject.toml` files, the inner list to the
         extras to include for that file. If "*", all extras are included,
         if None, no extras are included.
+
     """
     paths_with_extras = _to_path_with_extras(paths, extras)  # type: ignore[arg-type]
     ignore_pins = ignore_pins or []


### PR DESCRIPTION


<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--152.org.readthedocs.build/en/152/

<!-- readthedocs-preview unidep end -->