### PR TITLE
Install from folder directly instead of `name @ file:///path/to/name`

### DIFF
--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -380,7 +380,7 @@ def test_pip_install_local_dependencies(tmp_path: Path) -> None:
     deps = get_python_dependencies(p, include_local_dependencies=True)
     assert deps.dependencies == [
         "foo",
-        f"local_package @ file://{local_package.as_posix()}",
+        local_package.as_posix(),
     ]
 
 

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -138,7 +138,7 @@ def get_python_dependencies(
         )
         for paths in local_dependencies.values():
             for path in paths:
-                dependencies.append(f"{path.name} @ file://{path.as_posix()}")
+                dependencies.append(path.as_posix())
 
     return Dependencies(dependencies=dependencies, extras=extras)
 


### PR DESCRIPTION
This change is because sometimes a
```
local_dependencies:
  - my_package
```
is not actually installed as `my_package` but perhaps as `foo.my_package` or something else altogether.


<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--180.org.readthedocs.build/en/180/

<!-- readthedocs-preview unidep end -->