### PR TITLE
Guess package name, re-implements #180

### DIFF
--- a/tests/test_setuptools_integration.py
+++ b/tests/test_setuptools_integration.py
@@ -3,6 +3,8 @@
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from unidep._setuptools_integration import (
     _package_name_from_path,
     _package_name_from_pyproject_toml,
@@ -66,3 +68,19 @@ def test_package_name_from_cfg(tmp_path: Path) -> None:
     )
     assert _package_name_from_path(tmp_path) == "setup_cfg_project"
     assert _package_name_from_setup_cfg(setup_cfg) == "setup_cfg_project"
+    missing = tmp_path / "missing" / "setup.cfg"
+    assert not missing.exists()
+    with pytest.raises(KeyError):
+        _package_name_from_setup_cfg(missing)
+
+    setup_cfg2 = tmp_path / "setup.cfg"
+    setup_cfg2.write_text(
+        textwrap.dedent(
+            """\
+            [metadata]
+            yolo = missing
+            """,
+        ),
+    )
+    with pytest.raises(KeyError):
+        _package_name_from_setup_cfg(setup_cfg2)

--- a/tests/test_setuptools_integration.py
+++ b/tests/test_setuptools_integration.py
@@ -1,0 +1,68 @@
+"""Tests for setuptools integration."""
+
+import textwrap
+from pathlib import Path
+
+from unidep._setuptools_integration import (
+    _package_name_from_path,
+    _package_name_from_pyproject_toml,
+    _package_name_from_setup_cfg,
+    _package_name_from_setup_py,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_package_name_from_path() -> None:
+    example = REPO_ROOT / "example"
+    # Could not find the package name, so it uses the folder name
+    assert _package_name_from_path(example) == "example"
+    # The following should read from the setup.py or pyproject.toml file
+    assert _package_name_from_path(example / "hatch_project") == "hatch_project"
+    assert (
+        _package_name_from_pyproject_toml(example / "hatch_project" / "pyproject.toml")
+        == "hatch_project"
+    )
+    assert _package_name_from_path(example / "hatch2_project") == "hatch2_project"
+    assert (
+        _package_name_from_pyproject_toml(example / "hatch2_project" / "pyproject.toml")
+        == "hatch2_project"
+    )
+    assert (
+        _package_name_from_path(example / "pyproject_toml_project")
+        == "pyproject_toml_project"
+    )
+    assert (
+        _package_name_from_pyproject_toml(
+            example / "pyproject_toml_project" / "pyproject.toml",
+        )
+        == "pyproject_toml_project"
+    )
+    assert _package_name_from_path(example / "setup_py_project") == "setup_py_project"
+    assert (
+        _package_name_from_setup_py(example / "setup_py_project" / "setup.py")
+        == "setup_py_project"
+    )
+    assert (
+        _package_name_from_path(example / "setuptools_project") == "setuptools_project"
+    )
+    assert (
+        _package_name_from_pyproject_toml(
+            example / "setuptools_project" / "pyproject.toml",
+        )
+        == "setuptools_project"
+    )
+
+
+def test_package_name_from_cfg(tmp_path: Path) -> None:
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        textwrap.dedent(
+            """\
+            [metadata]
+            name = setup_cfg_project
+            """,
+        ),
+    )
+    assert _package_name_from_path(tmp_path) == "setup_cfg_project"
+    assert _package_name_from_setup_cfg(setup_cfg) == "setup_cfg_project"

--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -380,7 +380,7 @@ def test_pip_install_local_dependencies(tmp_path: Path) -> None:
     deps = get_python_dependencies(p, include_local_dependencies=True)
     assert deps.dependencies == [
         "foo",
-        local_package.as_posix(),
+        f"local_package @ file://{local_package.as_posix()}",
     ]
 
 

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -6,7 +6,9 @@ This module provides setuptools integration for unidep.
 
 from __future__ import annotations
 
+import contextlib
 import os
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -20,9 +22,17 @@ from unidep.utils import (
     warn,
 )
 
-if TYPE_CHECKING:
-    import sys
+try:  # pragma: no cover
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+    HAS_TOML = True
+except ImportError:  # pragma: no cover
+    HAS_TOML = False
 
+
+if TYPE_CHECKING:
     from setuptools import Distribution
 
     from unidep.platform_definitions import (
@@ -138,9 +148,26 @@ def get_python_dependencies(
         )
         for paths in local_dependencies.values():
             for path in paths:
-                dependencies.append(path.as_posix())
+                name = _package_name_from_path(path)
+                dependencies.append(f"{name} @ file://{path.as_posix()}")
 
     return Dependencies(dependencies=dependencies, extras=extras)
+
+
+def _package_name_from_path(path: Path) -> str:
+    """Get the package name from a path."""
+    toml = path / "pyproject.toml"
+    if toml.exists() and HAS_TOML:
+        with toml.open("rb") as f:
+            data = tomllib.load(f)
+        with contextlib.suppress(KeyError):
+            # PEP 621: setuptools, flit, hatch, pdm
+            return data["package"]["name"]
+        with contextlib.suppress(KeyError):
+            # poetry doesn't follow any standard
+            return data["tool"]["poetry"]["name"]
+    # Best guess for the package name is folder name.
+    return path.name
 
 
 def _deps(requirements_file: Path) -> Dependencies:  # pragma: no cover

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -192,7 +192,7 @@ def _package_name_from_setup_py(file_path: Path) -> str:
 
 
 def _package_name_from_pyproject_toml(file_path: Path) -> str:
-    if not HAS_TOML:
+    if not HAS_TOML:  # pragma: no cover
         msg = "toml is required to parse pyproject.toml files."
         raise ImportError(msg)
     with file_path.open("rb") as f:

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -180,13 +180,14 @@ def _package_name_from_setup_py(file_path: Path) -> str:
             if isinstance(node.func, ast.Name) and node.func.id == "setup":
                 for keyword in node.keywords:
                     if keyword.arg == "name":
-                        self.package_name = keyword.value.s  # type: ignore[attr-defined]
+                        self.package_name = keyword.value.value  # type: ignore[attr-defined]
 
     visitor = SetupVisitor()
     visitor.visit(tree)
     if visitor.package_name is None:
         msg = "Could not find the package name in the setup.py file."
         raise KeyError(msg)
+    assert isinstance(visitor.package_name, str)
     return visitor.package_name
 
 
@@ -198,11 +199,11 @@ def _package_name_from_pyproject_toml(file_path: Path) -> str:
         data = tomllib.load(f)
     with contextlib.suppress(KeyError):
         # PEP 621: setuptools, flit, hatch, pdm
-        return data["package"]["name"]
+        return data["project"]["name"]
     with contextlib.suppress(KeyError):
         # poetry doesn't follow any standard
         return data["tool"]["poetry"]["name"]
-    msg = "Could not find the package name in the pyproject.toml file."
+    msg = f"Could not find the package name in the pyproject.toml file: {data}."
     raise KeyError(msg)
 
 


### PR DESCRIPTION
From #180:

This change is because sometimes a
```
local_dependencies:
  - my_package
```
is not actually installed as `my_package` but perhaps as `foo.my_package` or something else altogether.


<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview unidep end -->