### PR TITLE
Make `tomli` a dependency for <3.11

### DIFF
--- a/.github/use-local-unidep.py
+++ b/.github/use-local-unidep.py
@@ -12,20 +12,14 @@ print(
 
 for project_dir in PROJECT_DIRS:
     # find the line with `requires = [` in `pyproject.toml` in each project
-    # directory and replace `"unidep"` or `"unidep[toml]"` with
-    # `"unidep @ file://<abs-path-to-repo-root>"`` or
-    # `"unidep[toml] @ file://<abs-path-to-repo-root>"` respectively
+    # directory and replace `"unidep"` with
+    # `"unidep @ file://<abs-path-to-repo-root>"``
     pyproject_toml = project_dir / "pyproject.toml"
     lines = pyproject_toml.read_text().splitlines()
     repo_root = REPO_ROOT.as_posix()  # convert to posix path for windows
     for i, line in enumerate(lines):
         if "requires = [" in line:
-            if "unidep[toml]" in line:
-                lines[i] = line.replace(
-                    "unidep[toml]",
-                    f"unidep[toml] @ file://{repo_root}",
-                )
-            elif "unidep" in line:
+            if "unidep" in line:
                 lines[i] = line.replace("unidep", f"unidep @ file://{repo_root}")
             break
     pyproject_toml.write_text("\n".join(lines))

--- a/.github/use-local-unidep.py
+++ b/.github/use-local-unidep.py
@@ -12,14 +12,20 @@ print(
 
 for project_dir in PROJECT_DIRS:
     # find the line with `requires = [` in `pyproject.toml` in each project
-    # directory and replace `"unidep"` with
-    # `"unidep @ file://<abs-path-to-repo-root>"``
+    # directory and replace `"unidep"` or `"unidep[toml]"` with
+    # `"unidep @ file://<abs-path-to-repo-root>"`` or
+    # `"unidep[toml] @ file://<abs-path-to-repo-root>"` respectively
     pyproject_toml = project_dir / "pyproject.toml"
     lines = pyproject_toml.read_text().splitlines()
     repo_root = REPO_ROOT.as_posix()  # convert to posix path for windows
     for i, line in enumerate(lines):
         if "requires = [" in line:
-            if "unidep" in line:
+            if "unidep[toml]" in line:
+                lines[i] = line.replace(
+                    "unidep[toml]",
+                    f"unidep[toml] @ file://{repo_root}",
+                )
+            elif "unidep" in line:
                 lines[i] = line.replace("unidep", f"unidep @ file://{repo_root}")
             break
     pyproject_toml.write_text("\n".join(lines))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "packaging",
     "ruamel.yaml",
     "typing_extensions; python_version < '3.8'",
+    "tomli; python_version < '3.11'",
 ]
 requires-python = ">=3.7"
 

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -36,14 +36,10 @@ if TYPE_CHECKING:
         from typing_extensions import Literal
 
 
-try:  # pragma: no cover
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib
-    HAS_TOML = True
-except ImportError:  # pragma: no cover
-    HAS_TOML = False
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
 
 
 def find_requirements_files(
@@ -166,15 +162,6 @@ def _parse_overwrite_pins(overwrite_pins: list[str]) -> dict[str, str | None]:
 @functools.lru_cache
 def _load(p: Path, yaml: YAML) -> dict[str, Any]:
     if p.suffix == ".toml":
-        if not HAS_TOML:  # pragma: no cover
-            msg = (
-                "❌ No toml support found in your Python installation."
-                " If you are using unidep from `pyproject.toml` and this"
-                " error occurs during installation, make sure you add"
-                '\n\n[build-system]\nrequires = [..., "unidep[toml]"]\n\n'
-                " Otherwise, please install it with `pip install tomli`."
-            )
-            raise ImportError(msg)
         with p.open("rb") as f:
             pyproject = tomllib.load(f)
             project_dependencies = pyproject.get("project", {}).get("dependencies", [])

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -24,14 +24,10 @@ from unidep.utils import (
     warn,
 )
 
-try:  # pragma: no cover
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib
-    HAS_TOML = True
-except ImportError:  # pragma: no cover
-    HAS_TOML = False
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
 
 
 if TYPE_CHECKING:
@@ -195,9 +191,6 @@ def _package_name_from_setup_py(file_path: Path) -> str:
 
 
 def _package_name_from_pyproject_toml(file_path: Path) -> str:
-    if not HAS_TOML:  # pragma: no cover
-        msg = "toml is required to parse pyproject.toml files."
-        raise ImportError(msg)
     with file_path.open("rb") as f:
         data = tomllib.load(f)
     with contextlib.suppress(KeyError):

--- a/unidep/utils.py
+++ b/unidep/utils.py
@@ -23,14 +23,10 @@ from unidep.platform_definitions import (
     validate_selector,
 )
 
-try:  # pragma: no cover
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        import tomli as tomllib
-    HAS_TOML = True
-except ImportError:  # pragma: no cover
-    HAS_TOML = False
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
 
 
 def add_comment_to_file(
@@ -88,15 +84,9 @@ def is_pip_installable(folder: str | Path) -> bool:  # pragma: no cover
 
     pyproject_path = path / "pyproject.toml"
     if pyproject_path.exists():
-        if HAS_TOML:
-            with pyproject_path.open("rb") as file:
-                pyproject_data = tomllib.load(file)
-                return "build-system" in pyproject_data
-        else:
-            with pyproject_path.open("r") as file:
-                for line in file:
-                    if line.strip().startswith("[build-system]"):
-                        return True
+        with pyproject_path.open("rb") as file:
+            pyproject_data = tomllib.load(file)
+            return "build-system" in pyproject_data
     return False
 
 
@@ -245,21 +235,10 @@ def extract_matching_platforms(comment: str) -> list[Platform]:
 
 
 def unidep_configured_in_toml(path: Path) -> bool:
-    """Check if dependencies are specified in pyproject.toml.
-
-    If a TOML parser is not available it finds `[tool.unidep]` in `pyproject.toml`.
-    """
-    if HAS_TOML:
-        with path.open("rb") as f:
-            data = tomllib.load(f)
-        return bool(data.get("tool", {}).get("unidep", {}))
-    # TODO[Bas]: will fail if defining dict in  # noqa: TD004, TD003, FIX002
-    # pyproject.toml directly e.g., it contains:
-    # `tool = {unidep = {dependencies = ...}}`
-    return any(  # pragma: no cover
-        line.lstrip().startswith("[tool.unidep")
-        for line in path.read_text().splitlines()
-    )
+    """Check if dependencies are specified in pyproject.toml."""
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return bool(data.get("tool", {}).get("unidep", {}))
 
 
 def split_path_and_extras(input_str: str | Path) -> tuple[Path, list[str]]:


### PR DESCRIPTION
I initially didn't add tomli as a dependency to keep the number of dependencies minimal. However, I ran into the problem of missing toml many times. So just to be safe, let's add it as a required dependency.
<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--244.org.readthedocs.build/en/244/

<!-- readthedocs-preview unidep end -->