### PR TITLE
Document UNIDEP_SKIP_LOCAL_DEPS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Try it now and streamline your development process!
     - [Implementation](#implementation)
   - [`[project.dependencies]` in `pyproject.toml` handling](#projectdependencies-in-pyprojecttoml-handling)
 - [:jigsaw: Build System Integration](#jigsaw-build-system-integration)
+  - [Environment Variables](#environment-variables)
+    - [`UNIDEP_SKIP_LOCAL_DEPS`](#unidep_skip_local_deps)
   - [Example packages](#example-packages)
   - [Setuptools Integration](#setuptools-integration)
   - [Hatchling Integration](#hatchling-integration)

--- a/README.md
+++ b/README.md
@@ -390,6 +390,26 @@ dependencies = [
 
 `unidep` seamlessly integrates with popular Python build systems to simplify dependency management in your projects.
 
+### Environment Variables
+
+#### `UNIDEP_SKIP_LOCAL_DEPS`
+
+When building wheels for distribution (e.g., for PyPI), you may want to exclude local dependencies to avoid hardcoded file paths in the wheel metadata. Set this environment variable to skip including local dependencies as `file://` URLs:
+
+```bash
+# For hatch projects
+UNIDEP_SKIP_LOCAL_DEPS=1 hatch build
+
+# For uv build
+UNIDEP_SKIP_LOCAL_DEPS=1 uv build
+
+# For python -m build
+UNIDEP_SKIP_LOCAL_DEPS=1 python -m build
+```
+
+> [!NOTE]
+> When this variable is set, local dependencies are skipped but their actual dependencies (extracted from `requirements.yaml` or `pyproject.toml`) are still included in the built wheel. This ensures the wheel remains functional while avoiding non-portable absolute paths.
+
 ### Example packages
 
 Explore these installable [example](example/) packages to understand how `unidep` integrates with different build tools and configurations:


### PR DESCRIPTION
## Summary
Add comprehensive documentation for the previously undocumented `UNIDEP_SKIP_LOCAL_DEPS` environment variable in the README.

## Background
During investigation of hardcoded local paths in Hatch-built wheels, we discovered that the `UNIDEP_SKIP_LOCAL_DEPS` environment variable provides the solution but was completely undocumented.

## Changes
- **Added new "Environment Variables" section** in Build System Integration
- **Documented `UNIDEP_SKIP_LOCAL_DEPS`** with clear explanation of its purpose
- **Provided usage examples** for common build tools:
  - `hatch build`
  - `uv build` 
  - `python -m build`
- **Explained the behavior** when the variable is set vs unset

## Problem Solved
When building wheels with local dependencies, UniDep includes them as `file://` URLs with absolute paths:
```
Requires-Dist: hatch-project@ file:///Users/bas.nijholt/Work/unidep/example/hatch_project
```

This makes wheels non-portable. Setting `UNIDEP_SKIP_LOCAL_DEPS=1` excludes these hardcoded paths while preserving the actual dependencies extracted from local packages.

## Verification
✅ Tested with both `hatch build` and `uv build`  
✅ Confirmed that dependencies are still included while removing hardcoded paths  
✅ Wheels built with this environment variable are portable

## Documentation Location
Added to the Build System Integration section as this is specifically relevant when building wheels for distribution.