### PR TITLE
Enhance UNIDEP_SKIP_LOCAL_DEPS documentation with context and rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,9 @@ dependencies = [
 
 #### `UNIDEP_SKIP_LOCAL_DEPS`
 
-When building wheels for distribution (e.g., for PyPI), you may want to exclude local dependencies to avoid hardcoded file paths in the wheel metadata. Set this environment variable to skip including local dependencies as `file://` URLs:
+Local dependencies are useful for monorepos, shared configuration files, and local development workflows where you're developing multiple related packages. However, when building wheels for distribution (e.g., for PyPI), including local dependencies creates hardcoded `file://` paths in the wheel metadata, making wheels non-portable.
+
+Set this environment variable to skip including local dependencies as `file://` URLs when building distributable artifacts:
 
 ```bash
 # For hatch projects
@@ -411,6 +413,8 @@ UNIDEP_SKIP_LOCAL_DEPS=1 python -m build
 
 > [!NOTE]
 > When this variable is set, local dependencies are skipped but their actual dependencies (extracted from `requirements.yaml` or `pyproject.toml`) are still included in the built wheel. This ensures the wheel remains functional while avoiding non-portable absolute paths.
+>
+> **Two contexts, same codebase**: Local dependencies are included by default (great for `unidep install` during development), but this environment variable provides the context switch needed when building for distribution.
 
 ### Example packages
 


### PR DESCRIPTION
## Summary
Enhance the existing `UNIDEP_SKIP_LOCAL_DEPS` documentation with better context about why local dependencies exist and when to use this environment variable.

## Context
Following user questions about why this environment variable exists in the first place, this PR adds clarity about the design rationale and use cases.

## Changes
- **Added context about local dependencies**: Explain they're useful for monorepos, shared config files, and local development workflows
- **Clarified the problem**: Hardcoded `file://` paths in wheel metadata make wheels non-portable  
- **Explained the design challenge**: Same codebase serves two different contexts (development vs distribution)
- **Added "Two contexts, same codebase" explanation**: Local dependencies included by default for development, but skipped when building for distribution

## Why This Matters
Users encountering this environment variable now understand:
1. **Why local dependencies exist**: Legitimate use cases for monorepos and local development
2. **Why the environment variable is needed**: Context switch between development and distribution builds  
3. **The design rationale**: Single codebase serving two different use cases

## Documentation Enhancement
The enhanced note explains the fundamental design decision: include local deps by default (great for `unidep install` during development), but provide a context switch for wheel building scenarios.