### PR TITLE
Deduplicate repeated local install targets in CLI installs

### DIFF
--- a/tests/shared_local_install_monorepo/project1/pyproject.toml
+++ b/tests/shared_local_install_monorepo/project1/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "project1"
+version = "0.0.1"

--- a/tests/shared_local_install_monorepo/project1/requirements.yaml
+++ b/tests/shared_local_install_monorepo/project1/requirements.yaml
@@ -1,0 +1,3 @@
+name: project1
+local_dependencies:
+  - ../shared

--- a/tests/shared_local_install_monorepo/project2/pyproject.toml
+++ b/tests/shared_local_install_monorepo/project2/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "project2"
+version = "0.0.1"

--- a/tests/shared_local_install_monorepo/project2/requirements.yaml
+++ b/tests/shared_local_install_monorepo/project2/requirements.yaml
@@ -1,0 +1,3 @@
+name: project2
+local_dependencies:
+  - ../shared

--- a/tests/shared_local_install_monorepo/shared/pyproject.toml
+++ b/tests/shared_local_install_monorepo/shared/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shared"
+version = "0.0.1"

--- a/tests/shared_local_install_monorepo/shared/requirements.yaml
+++ b/tests/shared_local_install_monorepo/shared/requirements.yaml
@@ -1,0 +1,2 @@
+name: shared
+dependencies: []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from unidep._cli import (
     _conda_root_prefix,
     _find_windows_path,
     _flatten_selected_dependency_entries,
+    _get_conda_executable,
     _identify_conda_executable,
     _install_all_command,
     _install_command,
@@ -142,6 +143,37 @@ def test_install_all_command(capsys: pytest.CaptureFixture) -> None:
     projects = [REPO_ROOT / "example" / p for p in EXAMPLE_PROJECTS]
     pkgs = " ".join([f"-e {p}" for p in sorted(projects)])
     assert f"pip install --no-deps {pkgs}`" in captured.out
+
+
+def test_install_command_deduplicates_shared_local_dependencies(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    fixture_root = REPO_ROOT / "tests" / "shared_local_install_monorepo"
+    monorepo = tmp_path / fixture_root.name
+    shutil.copytree(fixture_root, monorepo)
+    shared = monorepo / "shared"
+    project1 = monorepo / "project1"
+    project2 = monorepo / "project2"
+
+    _install_command(
+        project1,
+        project2,
+        conda_executable="",  # type: ignore[arg-type]
+        conda_env_name=None,
+        conda_env_prefix=None,
+        conda_lock_file=None,
+        dry_run=True,
+        editable=True,
+        no_dependencies=True,
+        no_uv=True,
+        verbose=False,
+    )
+
+    captured = capsys.readouterr()
+    pkgs = " ".join([f"-e {p}" for p in sorted((project1, project2, shared))])
+    assert f"pip install --no-deps {pkgs}`" in captured.out
+    assert captured.out.count(f"-e {shared}") == 1
 
 
 def mock_uv_env(tmp_path: Path) -> dict[str, str]:
@@ -845,6 +877,21 @@ def test_conda_root_prefix_uses_conda_info_when_env_vars_are_unset(
         conda_cli_command_json.assert_called_once_with("conda", "info")
     finally:
         _conda_info.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("which", "env_var"),
+    [("conda", "CONDA_EXE"), ("micromamba", "MAMBA_EXE")],
+)
+def test_get_conda_executable_uses_env_var_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    which: CondaExecutable,
+    env_var: str,
+) -> None:
+    exe = f"/tmp/{which}"
+    monkeypatch.setenv(env_var, exe)
+    with patch("shutil.which", return_value=None):
+        assert _get_conda_executable(which) == exe
 
 
 def test_unidep_version_uses_rich_when_available(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -884,11 +884,12 @@ def test_conda_root_prefix_uses_conda_info_when_env_vars_are_unset(
     [("conda", "CONDA_EXE"), ("micromamba", "MAMBA_EXE")],
 )
 def test_get_conda_executable_uses_env_var_fallback(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     which: CondaExecutable,
     env_var: str,
 ) -> None:
-    exe = f"/tmp/{which}"
+    exe = str(tmp_path / which)
     monkeypatch.setenv(env_var, exe)
     with patch("shutil.which", return_value=None):
         assert _get_conda_executable(which) == exe

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -1015,7 +1015,7 @@ def _pip_install_local(
         subprocess.run(pip_command, check=True)
 
 
-def _install_command(  # noqa: PLR0912, PLR0915
+def _install_command(  # noqa: C901, PLR0912, PLR0915
     *files: Path,
     conda_executable: CondaExecutable | None,
     conda_env_name: str | None,

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -1146,12 +1146,13 @@ def _install_command(  # noqa: PLR0912, PLR0915
         names = {k.name: [dep.name for dep in v] for k, v in local_dependencies.items()}
         print(f"📝 Found local dependencies: {names}\n")
         installable_set = {p.resolve() for p in installable}
-        installable += [
-            dep
-            for deps in local_dependencies.values()
-            for dep in deps
-            if dep.resolve() not in installable_set
-        ]
+        for deps in local_dependencies.values():
+            for dep in deps:
+                resolved_dep = dep.resolve()
+                if resolved_dep in installable_set:
+                    continue
+                installable_set.add(resolved_dep)
+                installable.append(dep)
         if installable:
             pip_flags = ["--no-deps"]  # we just ran pip/conda install, so skip
             if verbose:


### PR DESCRIPTION
 ## Problem

`unidep install` / `unidep install-all` collected local install targets from `parse_local_dependencies()`, but only deduplicated them against the initial root projects. If two projects both depended on the same local package, that shared package could be appended more than once.

That produced commands like:
```shell
pip install --no-deps -e project1 -e project2 -e shared -e shared
```

## Changes
  - Deduplicate local install targets as they are accumulated in unidep._cli._install_command.
  - Add a regression fixture monorepo under `tests/shared_local_install_monorepo/`.
  - Add a CLI regression test to assert a shared local dependency is installed exactly once.
  - Add focused coverage tests for `_get_conda_executable()` env-var fallback so the suite remains at 100% coverage.

## User impact

No behavior change for unique local dependencies. The only user-visible change is that duplicate shared local packages are no longer passed repeatedly to pip install.

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--286.org.readthedocs.build/en/286/

<!-- readthedocs-preview unidep end -->