### PR TITLE
Fix README logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation](https://readthedocs.org/projects/unidep/badge/?version=latest)](https://unidep.readthedocs.io/)
 [![Python Bytes](https://img.shields.io/badge/Python_Bytes-366-D7F9FF?logo=applepodcasts&labelColor=blue)](https://www.youtube.com/live/PRaTs3PnJvI?si=UrVozo81Pj8WcyXh&t=489)
 
-<img src="docs/source/logo.svg" alt="UniDep logo" align="right" width="240" />
+<img src="https://raw.githubusercontent.com/conda-incubator/unidep/refs/heads/main/docs/source/logo.svg" alt="UniDep logo" align="right" width="240" />
 
 > UniDep streamlines Python project dependency management by unifying Conda and Pip packages in a single system.
 > [Learn when to use UniDep](#q-when-to-use-unidep) in our [FAQ](#-faq).


### PR DESCRIPTION
## Summary
- use the raw GitHub URL for the README logo so docs renderers can fetch it

## Verification
- pre-commit hooks ran during commit
- verified committed README diff contains the full raw logo URL

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--293.org.readthedocs.build/en/293/

<!-- readthedocs-preview unidep end -->