### PR TITLE
Refine doctor Conda root parsing

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -172,6 +172,24 @@ def test_shell_profile_scan_reports_multiple_condabin_initializer_roots(
     assert ".zshrc:2" in finding.details
 
 
+def test_shell_profile_scan_reports_custom_condabin_initializer_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        'export PATH="/opt/toolchain/condabin:$HOME/miniconda3/condabin:$PATH"',
+    )
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    finding = report.finding_by_code("multiple-conda-initializer-roots")
+    assert finding is not None
+    assert finding.level == "warning"
+    assert "/opt/toolchain" in finding.details
+    assert "$HOME/miniconda3" in finding.details
+    assert ".zshrc:1" in finding.details
+
+
 def test_shell_profile_scan_reports_multiple_conda_roots_on_one_path_line(
     tmp_path: Path,
 ) -> None:
@@ -249,6 +267,22 @@ def test_shell_profile_scan_allows_mamba_hook_inside_generic_conda_root(
 
     assert report.finding_by_code("multiple-conda-initializers") is None
     assert report.finding_by_code("multiple-conda-initializer-roots") is None
+
+
+def test_shell_profile_scan_allows_mamba_hook_inside_custom_conda_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    for root in ("/opt/toolchain", "/srv/conda-24"):
+        zshrc.write_text(
+            f"source {root}/etc/profile.d/conda.sh\n"
+            f'eval "$({root}/bin/mamba shell hook -s zsh)"',
+        )
+
+        report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+        assert report.finding_by_code("multiple-conda-initializers") is None
+        assert report.finding_by_code("multiple-conda-initializer-roots") is None
 
 
 def test_shell_profile_scan_ignores_env_bin_inside_generic_conda_root(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -188,6 +188,36 @@ def test_shell_profile_scan_reports_multiple_conda_roots_on_one_path_line(
     assert ".zshrc:1" in finding.details
 
 
+def test_shell_profile_scan_ignores_non_conda_path_entries_on_conda_line(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text('export PATH="/usr/local/bin:$HOME/miniconda3/bin:$PATH"')
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    assert _line_conda_roots(zshrc.read_text()) == ["$HOME/miniconda3"]
+    assert report.finding_by_code("multiple-conda-initializer-roots") is None
+
+
+def test_shell_profile_scan_reports_generic_conda_sh_initializer_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        "source /opt/conda/etc/profile.d/conda.sh\n"
+        'source "$HOME/miniconda3/etc/profile.d/conda.sh"',
+    )
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    finding = report.finding_by_code("multiple-conda-initializer-roots")
+    assert finding is not None
+    assert finding.level == "warning"
+    assert "/opt/conda" in finding.details
+    assert "$HOME/miniconda3" in finding.details
+
+
 def test_shell_profile_scan_parses_windows_style_conda_root() -> None:
     roots = _line_conda_roots(
         r'eval "$(C:\Users\runneradmin\AppData\Local\Temp\case/miniconda3/bin/mamba shell hook -s zsh)"',

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -188,6 +188,24 @@ def test_shell_profile_scan_reports_multiple_conda_roots_on_one_path_line(
     assert ".zshrc:1" in finding.details
 
 
+def test_shell_profile_scan_reports_suffixed_stale_conda_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        'export PATH="$HOME/miniconda3/bin:$HOME/miniconda3-old/bin:$PATH"',
+    )
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    finding = report.finding_by_code("multiple-conda-initializer-roots")
+    assert finding is not None
+    assert finding.level == "warning"
+    assert "$HOME/miniconda3" in finding.details
+    assert "$HOME/miniconda3-old" in finding.details
+    assert ".zshrc:1" in finding.details
+
+
 def test_shell_profile_scan_ignores_non_conda_path_entries_on_conda_line(
     tmp_path: Path,
 ) -> None:
@@ -216,6 +234,35 @@ def test_shell_profile_scan_reports_generic_conda_sh_initializer_root(
     assert finding.level == "warning"
     assert "/opt/conda" in finding.details
     assert "$HOME/miniconda3" in finding.details
+
+
+def test_shell_profile_scan_allows_mamba_hook_inside_generic_conda_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        "source /opt/conda/etc/profile.d/conda.sh\n"
+        'eval "$(/opt/conda/bin/mamba shell hook -s zsh)"',
+    )
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    assert report.finding_by_code("multiple-conda-initializers") is None
+    assert report.finding_by_code("multiple-conda-initializer-roots") is None
+
+
+def test_shell_profile_scan_ignores_env_bin_inside_generic_conda_root(
+    tmp_path: Path,
+) -> None:
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        "source /opt/conda/etc/profile.d/conda.sh\n"
+        'export PATH="/opt/conda/envs/foo/bin:$PATH"',
+    )
+
+    report = run_doctor_checks(home=tmp_path, env={}, path_env="")
+
+    assert report.finding_by_code("multiple-conda-initializer-roots") is None
 
 
 def test_shell_profile_scan_parses_windows_style_conda_root() -> None:

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -56,11 +56,15 @@ SHADOWED_EXECUTABLES = (
 )
 CONDA_ROOT_PATTERN = re.compile(
     r"(?P<root>(?:~|\$HOME|\$\{HOME\}|[A-Za-z]:[/\\]|[/\\])[^\"':;$()]*?)"
-    r"(?:[/\\]etc[/\\]profile\.d[/\\]conda\.sh"
+    r"(?P<terminator>[/\\]etc[/\\]profile\.d[/\\]conda\.sh"
     r"|[/\\]bin[/\\](?:conda|mamba|micromamba)\b"
     r"|[/\\](?:bin|condabin)(?=[:;\"' )]|$))",
     re.IGNORECASE,
 )
+CONDA_ROOT_NAMES = {
+    "conda",
+    *(marker for markers in CONDA_DISTRIBUTIONS.values() for marker in markers),
+}
 
 
 @dataclass(frozen=True)
@@ -380,8 +384,33 @@ def _line_conda_distributions(line: str) -> list[str]:
 
 def _line_conda_roots(line: str) -> list[str]:
     return [
-        match.group("root").rstrip("/") for match in CONDA_ROOT_PATTERN.finditer(line)
+        match.group("root").rstrip("/")
+        for match in CONDA_ROOT_PATTERN.finditer(line)
+        if _is_conda_root_match(
+            match.group("root"),
+            match.group("terminator"),
+        )
     ]
+
+
+def _is_conda_root_match(root: str, terminator: str) -> bool:
+    if _terminator_is_explicit_conda(terminator):
+        return True
+    return _root_looks_conda_like(root)
+
+
+def _terminator_is_explicit_conda(terminator: str) -> bool:
+    normalized = terminator.replace("\\", "/").casefold()
+    return normalized.endswith("/etc/profile.d/conda.sh") or bool(
+        re.search(r"/bin/(?:conda|mamba|micromamba)\b", normalized),
+    )
+
+
+def _root_looks_conda_like(root: str) -> bool:
+    parts = [
+        part.casefold() for part in re.split(r"[/\\]+", root.rstrip("/\\")) if part
+    ]
+    return any(part in CONDA_ROOT_NAMES for part in parts)
 
 
 def _conda_root_initializer(
@@ -394,9 +423,7 @@ def _conda_root_initializer(
 ) -> _CondaInitializer | None:
     distribution = _conda_root_distribution(root)
     if distribution is None:
-        if not fallback_distributions:
-            return None
-        distribution = fallback_distributions[0]
+        distribution = fallback_distributions[0] if fallback_distributions else "conda"
     return _CondaInitializer(
         distribution=distribution,
         profile=profile,

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -65,6 +65,8 @@ CONDA_ROOT_NAMES = {
     "conda",
     *(marker for markers in CONDA_DISTRIBUTIONS.values() for marker in markers),
 }
+SUFFIXED_CONDA_ROOT_NAMES = CONDA_ROOT_NAMES - {"conda", "mamba"}
+CONDA_ROOT_SUFFIX_SEPARATORS = ("-", "_", ".")
 
 
 @dataclass(frozen=True)
@@ -407,10 +409,22 @@ def _terminator_is_explicit_conda(terminator: str) -> bool:
 
 
 def _root_looks_conda_like(root: str) -> bool:
-    parts = [
-        part.casefold() for part in re.split(r"[/\\]+", root.rstrip("/\\")) if part
-    ]
-    return any(part in CONDA_ROOT_NAMES for part in parts)
+    parts = _conda_root_parts(root)
+    return bool(parts) and _root_part_looks_conda_like(parts[-1])
+
+
+def _root_part_looks_conda_like(part: str) -> bool:
+    if part in CONDA_ROOT_NAMES:
+        return True
+    return any(
+        part.startswith(f"{root_name}{separator}")
+        for root_name in SUFFIXED_CONDA_ROOT_NAMES
+        for separator in CONDA_ROOT_SUFFIX_SEPARATORS
+    )
+
+
+def _conda_root_parts(root: str) -> list[str]:
+    return [part.casefold() for part in re.split(r"[/\\]+", root.rstrip("/\\")) if part]
 
 
 def _conda_root_initializer(
@@ -435,9 +449,11 @@ def _conda_root_initializer(
 
 def _conda_root_distribution(root: str) -> str | None:
     distributions = _line_conda_distributions(root)
-    if not distributions:
-        return None
-    return distributions[0]
+    if distributions:
+        return distributions[0]
+    if "conda" in _conda_root_parts(root):
+        return "conda"
+    return None
 
 
 def _normalize_conda_root(root: str, home: Path) -> str:

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -265,7 +265,7 @@ def _check_shell_profiles(home: Path) -> list[DoctorFinding]:
     initializers, read_errors = _find_conda_initializers(home)
     distributions = {initializer.distribution for initializer in initializers}
     findings = []
-    if len(distributions) > 1:
+    if len(distributions) > 1 and not _all_initializers_share_one_root(initializers):
         details = "; ".join(
             initializer.format_location(home) for initializer in initializers
         )
@@ -403,8 +403,12 @@ def _is_conda_root_match(root: str, terminator: str) -> bool:
 
 def _terminator_is_explicit_conda(terminator: str) -> bool:
     normalized = terminator.replace("\\", "/").casefold()
-    return normalized.endswith("/etc/profile.d/conda.sh") or bool(
-        re.search(r"/bin/(?:conda|mamba|micromamba)\b", normalized),
+    return (
+        normalized == "/condabin"
+        or normalized.endswith("/etc/profile.d/conda.sh")
+        or bool(
+            re.search(r"/bin/(?:conda|mamba|micromamba)\b", normalized),
+        )
     )
 
 
@@ -444,6 +448,17 @@ def _conda_root_initializer(
         line_number=line_number,
         root=root,
         normalized_root=_normalize_conda_root(root, home),
+    )
+
+
+def _all_initializers_share_one_root(initializers: list[_CondaInitializer]) -> bool:
+    roots = {
+        initializer.normalized_root
+        for initializer in initializers
+        if initializer.normalized_root is not None
+    }
+    return len(roots) == 1 and all(
+        initializer.normalized_root is not None for initializer in initializers
     )
 
 


### PR DESCRIPTION
## Summary
- ignore unrelated PATH entries such as `/usr/local/bin` when they appear on the same shell line as a Conda root
- keep explicit Conda shell initializers such as `/opt/conda/etc/profile.d/conda.sh` reportable even when the root name is generic
- treat `condabin` PATH entries as explicit Conda roots, including custom prefixes such as `/opt/toolchain/condabin`
- avoid treating environment `bin` paths under a generic Conda root, such as `/opt/conda/envs/foo/bin`, as separate installation roots
- avoid false multiple-initializer warnings when `conda.sh` and a `mamba` hook belong to the same custom Conda root
- preserve stale suffixed root detection for basename matches such as `miniconda3-old`
- default explicit unknown Conda roots to the `conda` distribution label instead of dropping them

## Test Plan
- `.venv/bin/python -m pytest tests/test_doctor.py -q --no-cov`
- `uvx ruff==0.9.9 check unidep/_doctor.py tests/test_doctor.py`
- `uvx ruff==0.9.9 format --check unidep/_doctor.py tests/test_doctor.py`
- `PATH=/home/basnijholt/Code/unidep/.venv/bin:$PATH CONDA_PREFIX=/home/basnijholt/Code/unidep/.venv CONDA_SHLVL=1 .venv/bin/python -m pytest`
