### PR TITLE
Add doctor tool version context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1489,7 +1489,7 @@ options:
 ### `unidep doctor`
 
 Use `unidep doctor` to run read-only diagnostics for common Python and Conda environment issues.
-It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, and PATH shadowing with tool version context.
+It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, and PATH shadowing for environment tools with version context.
 See `unidep doctor -h` for more information:
 
 <!-- CODE:BASH:START -->
@@ -1505,7 +1505,8 @@ usage: unidep doctor [-h] [--json] [--strict]
 Run read-only diagnostics for common Python and Conda environment issues,
 including stacked environments, shell startup conflicts such as stale
 Conda/Mamba install roots, interpreter/environment mismatches, Homebrew Python
-inside Conda environments, and PATH shadowing with tool version context.
+inside Conda environments, and PATH shadowing for environment tools with version
+context.
 
 options:
   -h, --help  show this help message and exit

--- a/README.md
+++ b/README.md
@@ -1505,8 +1505,8 @@ usage: unidep doctor [-h] [--json] [--strict]
 Run read-only diagnostics for common Python and Conda environment issues,
 including stacked environments, shell startup conflicts such as stale
 Conda/Mamba install roots, interpreter/environment mismatches, Homebrew Python
-inside Conda environments, and PATH shadowing for environment tools with version
-context.
+inside Conda environments, and PATH shadowing for environment tools with
+version context.
 
 options:
   -h, --help  show this help message and exit

--- a/README.md
+++ b/README.md
@@ -1489,7 +1489,7 @@ options:
 ### `unidep doctor`
 
 Use `unidep doctor` to run read-only diagnostics for common Python and Conda environment issues.
-It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, and PATH shadowing.
+It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, and PATH shadowing with tool version context.
 See `unidep doctor -h` for more information:
 
 <!-- CODE:BASH:START -->
@@ -1505,7 +1505,7 @@ usage: unidep doctor [-h] [--json] [--strict]
 Run read-only diagnostics for common Python and Conda environment issues,
 including stacked environments, shell startup conflicts such as stale
 Conda/Mamba install roots, interpreter/environment mismatches, Homebrew Python
-inside Conda environments, and PATH shadowing.
+inside Conda environments, and PATH shadowing with tool version context.
 
 options:
   -h, --help  show this help message and exit

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,6 +13,7 @@ from unidep._doctor import (
     DoctorFinding,
     DoctorReport,
     _line_conda_roots,
+    _shadowed_version_spans,
     format_doctor_report,
     print_doctor_report,
     run_doctor_checks,
@@ -72,7 +73,7 @@ def _install_fake_rich(
                 def append(self, value, *, style=None):
                     self.parts.append(value)
                     if style is not None:
-                        self.styles.append(style)
+                        self.styles.append((value, style))
 
                 def __str__(self):
                     return "".join(self.parts)
@@ -984,6 +985,40 @@ def test_run_doctor_command_uses_rich_for_summary_when_available(
     assert exit_code == 0
     assert captured.out.startswith(f"RICH:{expected_report}\nSTYLES:")
     assert "No environment issues found" in captured.out
+
+
+def test_rich_report_styles_shadowed_tool_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    report = DoctorReport(
+        (
+            DoctorFinding(
+                code="shadowed-uv",
+                level="info",
+                title="Multiple `uv` executables are on PATH.",
+                details="/first/uv (uv 0.8.1), /second/uv (uv 0.4.0)",
+                recommendation="Check PATH ordering.",
+            ),
+        ),
+    )
+    expected_report = format_doctor_report(report)
+    saved_modules = _install_fake_rich(tmp_path, monkeypatch)
+    try:
+        print_doctor_report(report)
+
+        captured = capsys.readouterr()
+    finally:
+        _restore_rich_modules(saved_modules)
+
+    assert captured.out.startswith(f"RICH:{expected_report}\nSTYLES:")
+    assert "('(uv 0.8.1)', 'bold cyan')" in captured.out
+    assert "('(uv 0.4.0)', 'bold cyan')" in captured.out
+
+
+def test_shadowed_version_spans_ignores_unclosed_version() -> None:
+    assert _shadowed_version_spans("/first/uv (uv 0.8.1") == []
 
 
 def test_rich_report_styles_multiple_finding_levels(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -712,6 +712,28 @@ def test_path_scan_ignores_expected_python_shadowing_from_running_env(
     assert report.finding_by_code("shadowed-python3") is None
 
 
+def test_path_scan_ignores_expected_pip_shadowing_from_running_env(
+    tmp_path: Path,
+) -> None:
+    env_bin = tmp_path / "env" / "bin"
+    system_bin = tmp_path / "system" / "bin"
+    _make_executable(env_bin / "python")
+    _make_executable(env_bin / "pip")
+    _make_executable(env_bin / "pip3")
+    _make_executable(system_bin / "pip")
+    _make_executable(system_bin / "pip3")
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=f"{env_bin}{os.pathsep}{system_bin}",
+        python_executable=str(env_bin / "python"),
+    )
+
+    assert report.finding_by_code("shadowed-pip") is None
+    assert report.finding_by_code("shadowed-pip3") is None
+
+
 def test_path_scan_reports_micromamba_shadowing(tmp_path: Path) -> None:
     first_bin = tmp_path / "first" / "bin"
     second_bin = tmp_path / "second" / "bin"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -754,11 +754,27 @@ def test_path_scan_reports_micromamba_shadowing(tmp_path: Path) -> None:
     assert str(second_bin / "micromamba") in finding.details
 
 
-def test_path_scan_reports_uv_shadowing_with_versions(tmp_path: Path) -> None:
+def test_path_scan_reports_uv_shadowing_with_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     first_bin = tmp_path / "first" / "bin"
     second_bin = tmp_path / "second" / "bin"
-    _make_executable(first_bin / "uv", "#!/bin/sh\necho 'uv 0.8.1'\n")
-    _make_executable(second_bin / "uv", "#!/bin/sh\necho 'uv 0.4.0'\n")
+    _make_executable(first_bin / "uv")
+    _make_executable(second_bin / "uv")
+
+    def run(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        root_name = command[0].replace("\\", "/").split("/")[-3]
+        version = {
+            "first": "uv 0.8.1",
+            "second": "uv 0.4.0",
+        }[root_name]
+        return subprocess.CompletedProcess(command, 0, stdout=f"{version}\n")
+
+    monkeypatch.setattr("unidep._doctor.subprocess.run", run)
 
     report = run_doctor_checks(
         home=tmp_path,
@@ -774,12 +790,20 @@ def test_path_scan_reports_uv_shadowing_with_versions(tmp_path: Path) -> None:
     assert f"{second_bin / 'uv'} (uv 0.4.0)" in finding.details
 
 
-def test_path_scan_warns_when_tool_version_probe_fails(tmp_path: Path) -> None:
+def test_path_scan_warns_when_tool_version_probe_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bin_dir = tmp_path / "bin"
-    _make_executable(
-        bin_dir / "uv",
-        "#!/bin/sh\necho 'broken uv' >&2\nexit 2\n",
-    )
+    _make_executable(bin_dir / "uv")
+
+    def run(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 2, stderr="broken uv\n")
+
+    monkeypatch.setattr("unidep._doctor.subprocess.run", run)
 
     report = run_doctor_checks(
         home=tmp_path,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import textwrap
 from typing import TYPE_CHECKING
@@ -25,9 +26,9 @@ if TYPE_CHECKING:
     import pytest
 
 
-def _make_executable(path: Path) -> None:
+def _make_executable(path: Path, content: str = "#!/bin/sh\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/bin/sh\n")
+    path.write_text(content)
     path.chmod(0o755)
 
 
@@ -709,6 +710,98 @@ def test_path_scan_reports_micromamba_shadowing(tmp_path: Path) -> None:
     assert finding.level == "info"
     assert str(first_bin / "micromamba") in finding.details
     assert str(second_bin / "micromamba") in finding.details
+
+
+def test_path_scan_reports_uv_shadowing_with_versions(tmp_path: Path) -> None:
+    first_bin = tmp_path / "first" / "bin"
+    second_bin = tmp_path / "second" / "bin"
+    _make_executable(first_bin / "uv", "#!/bin/sh\necho 'uv 0.8.1'\n")
+    _make_executable(second_bin / "uv", "#!/bin/sh\necho 'uv 0.4.0'\n")
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=f"{first_bin}{os.pathsep}{second_bin}",
+        python_executable=sys.executable,
+    )
+
+    finding = report.finding_by_code("shadowed-uv")
+    assert finding is not None
+    assert finding.level == "info"
+    assert f"{first_bin / 'uv'} (uv 0.8.1)" in finding.details
+    assert f"{second_bin / 'uv'} (uv 0.4.0)" in finding.details
+
+
+def test_path_scan_warns_when_tool_version_probe_fails(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(
+        bin_dir / "uv",
+        "#!/bin/sh\necho 'broken uv' >&2\nexit 2\n",
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=str(bin_dir),
+        python_executable=sys.executable,
+    )
+
+    finding = report.finding_by_code("uv-version-probe-failed")
+    assert finding is not None
+    assert finding.level == "warning"
+    assert str(bin_dir / "uv") in finding.details
+    assert "exit code 2" in finding.details
+    assert "broken uv" in finding.details
+
+
+def test_path_scan_warns_when_tool_version_probe_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(bin_dir / "uv")
+
+    def run(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="uv --version", timeout=2)
+
+    monkeypatch.setattr("unidep._doctor.subprocess.run", run)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=str(bin_dir),
+        python_executable=sys.executable,
+    )
+
+    finding = report.finding_by_code("uv-version-probe-failed")
+    assert finding is not None
+    assert "timed out after 2 seconds" in finding.details
+
+
+def test_path_scan_warns_when_tool_version_probe_cannot_execute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(bin_dir / "uv")
+
+    def run(*_args: object, **_kwargs: object) -> None:
+        error_message = "exec format error"
+        raise OSError(error_message)
+
+    monkeypatch.setattr("unidep._doctor.subprocess.run", run)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=str(bin_dir),
+        python_executable=sys.executable,
+    )
+
+    finding = report.finding_by_code("uv-version-probe-failed")
+    assert finding is not None
+    assert str(bin_dir / "uv") in finding.details
+    assert "exec format error" in finding.details
 
 
 def test_path_scan_honors_pathext_for_shadowing(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -673,7 +673,7 @@ def test_path_scan_reports_non_python_interpreter_name_mismatch(
     assert str(running_python) in finding.details
 
 
-def test_path_scan_reports_python_shadowing(tmp_path: Path) -> None:
+def test_path_scan_ignores_python_shadowing(tmp_path: Path) -> None:
     first_bin = tmp_path / "first" / "bin"
     second_bin = tmp_path / "second" / "bin"
     _make_executable(first_bin / "python")
@@ -686,11 +686,30 @@ def test_path_scan_reports_python_shadowing(tmp_path: Path) -> None:
         python_executable=str(first_bin / "python"),
     )
 
-    finding = report.finding_by_code("shadowed-python")
-    assert finding is not None
-    assert finding.level == "info"
-    assert str(first_bin / "python") in finding.details
-    assert str(second_bin / "python") in finding.details
+    assert report.finding_by_code("shadowed-python") is None
+
+
+def test_path_scan_ignores_expected_python_shadowing_from_running_env(
+    tmp_path: Path,
+) -> None:
+    env_bin = tmp_path / "env" / "bin"
+    system_bin = tmp_path / "system" / "bin"
+    _make_executable(env_bin / "python")
+    _make_executable(env_bin / "python3")
+    _make_executable(system_bin / "python")
+    _make_executable(system_bin / "python3")
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env=f"{env_bin}{os.pathsep}{system_bin}",
+        python_executable=str(env_bin / "python"),
+    )
+
+    assert report.finding_by_code("path-python-mismatch") is None
+    assert report.finding_by_code("path-python3-mismatch") is None
+    assert report.finding_by_code("shadowed-python") is None
+    assert report.finding_by_code("shadowed-python3") is None
 
 
 def test_path_scan_reports_micromamba_shadowing(tmp_path: Path) -> None:
@@ -810,21 +829,21 @@ def test_path_scan_honors_pathext_for_shadowing(
 ) -> None:
     first_bin = tmp_path / "first" / "bin"
     second_bin = tmp_path / "second" / "bin"
-    _make_executable(first_bin / "python.exe")
-    _make_executable(second_bin / "python.EXE")
+    _make_executable(first_bin / "pip.exe")
+    _make_executable(second_bin / "pip.EXE")
 
     report = run_doctor_checks(
         home=tmp_path,
         env={"PATHEXT": ".COM;.EXE;.BAT"},
         path_env=f"{first_bin}{os.pathsep}{second_bin}",
-        python_executable=str(first_bin / "python.exe"),
+        python_executable=sys.executable,
     )
 
-    finding = report.finding_by_code("shadowed-python")
+    finding = report.finding_by_code("shadowed-pip")
     assert finding is not None
     details = finding.details.casefold()
-    assert str(first_bin / "python.exe").casefold() in details
-    assert str(second_bin / "python.EXE").casefold() in details
+    assert str(first_bin / "pip.exe").casefold() in details
+    assert str(second_bin / "pip.EXE").casefold() in details
 
 
 def test_run_doctor_command_prints_summary(
@@ -1036,7 +1055,7 @@ def test_rich_report_styles_multiple_finding_levels(
                 recommendation="fix the error",
             ),
             DoctorFinding(
-                code="shadowed-python",
+                code="shadowed-pip",
                 level="info",
                 title="An info finding.",
                 details="second detail",

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -749,7 +749,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "issues, including stacked environments, shell startup conflicts "
             "such as stale Conda/Mamba install roots, interpreter/environment "
             "mismatches, Homebrew Python inside Conda environments, and PATH "
-            "shadowing with tool version context."
+            "shadowing for environment tools with version context."
         ),
         formatter_class=_HelpFormatter,
     )

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -749,7 +749,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "issues, including stacked environments, shell startup conflicts "
             "such as stale Conda/Mamba install roots, interpreter/environment "
             "mismatches, Homebrew Python inside Conda environments, and PATH "
-            "shadowing."
+            "shadowing with tool version context."
         ),
         formatter_class=_HelpFormatter,
     )

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -673,7 +673,11 @@ def _check_path(
         matches = _which_all(executable, path_env, path_extensions=env.get("PATHEXT"))
         versions = [_probe_executable_version(match) for match in matches]
         findings.extend(_version_probe_findings(executable, versions))
-        if len(matches) > 1:
+        if len(matches) > 1 and not _first_match_is_expected_pip(
+            executable,
+            matches[0],
+            python_path,
+        ):
             findings.append(
                 DoctorFinding(
                     code=f"shadowed-{executable}",
@@ -687,6 +691,17 @@ def _check_path(
                 ),
             )
     return findings
+
+
+def _first_match_is_expected_pip(
+    executable: str,
+    match: Path,
+    python_executable: Path,
+) -> bool:
+    return executable in {"pip", "pip3"} and _same_path(
+        match.parent,
+        python_executable.parent,
+    )
 
 
 def _probe_executable_version(path: Path) -> _ExecutableVersion:

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import os
 import re
+import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -53,7 +54,9 @@ SHADOWED_EXECUTABLES = (
     "conda",
     "mamba",
     "micromamba",
+    "uv",
 )
+VERSION_PROBE_TIMEOUT_SECONDS = 2
 CONDA_ROOT_PATTERN = re.compile(
     r"(?P<root>(?:~|\$HOME|\$\{HOME\}|[A-Za-z]:[/\\]|[/\\])[^\"':;$()]*?)"
     r"(?P<terminator>[/\\]etc[/\\]profile\.d[/\\]conda\.sh"
@@ -139,6 +142,18 @@ class _ShellProfileReadError:
         except ValueError:  # pragma: no cover
             profile = self.profile
         return f"{profile}: {self.error}"
+
+
+@dataclass(frozen=True)
+class _ExecutableVersion:
+    path: Path
+    version: str | None = None
+    error: str | None = None
+
+    def format_details(self) -> str:
+        if self.version:
+            return f"{self.path} ({self.version})"
+        return str(self.path)
 
 
 def run_doctor_command(
@@ -604,13 +619,15 @@ def _check_path(
 
     for executable in SHADOWED_EXECUTABLES:
         matches = _which_all(executable, path_env, path_extensions=env.get("PATHEXT"))
+        versions = [_probe_executable_version(match) for match in matches]
+        findings.extend(_version_probe_findings(executable, versions))
         if len(matches) > 1:
             findings.append(
                 DoctorFinding(
                     code=f"shadowed-{executable}",
                     level="info",
                     title=f"Multiple `{executable}` executables are on PATH.",
-                    details=", ".join(str(match) for match in matches),
+                    details=", ".join(version.format_details() for version in versions),
                     recommendation=(
                         "Check PATH ordering if this command resolves to an "
                         "unexpected environment."
@@ -618,6 +635,61 @@ def _check_path(
                 ),
             )
     return findings
+
+
+def _probe_executable_version(path: Path) -> _ExecutableVersion:
+    try:
+        completed = subprocess.run(
+            [os.fspath(path), "--version"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=VERSION_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return _ExecutableVersion(
+            path=path,
+            error=f"timed out after {VERSION_PROBE_TIMEOUT_SECONDS} seconds",
+        )
+    except OSError as error:
+        return _ExecutableVersion(path=path, error=str(error))
+
+    output = _first_nonempty_line(completed.stdout) or _first_nonempty_line(
+        completed.stderr,
+    )
+    if completed.returncode:
+        details = output or "no version output"
+        return _ExecutableVersion(
+            path=path,
+            error=f"exit code {completed.returncode}: {details}",
+        )
+    return _ExecutableVersion(path=path, version=output)
+
+
+def _first_nonempty_line(output: str | None) -> str | None:
+    if not output:
+        return None
+    return next((line.strip() for line in output.splitlines() if line.strip()), None)
+
+
+def _version_probe_findings(
+    executable: str,
+    versions: list[_ExecutableVersion],
+) -> list[DoctorFinding]:
+    return [
+        DoctorFinding(
+            code=f"{executable}-version-probe-failed",
+            level="warning",
+            title=f"Could not read `{executable}` version.",
+            details=f"{version.path}: {version.error}",
+            recommendation=(
+                f"Run `{version.path} --version` manually and remove or fix this "
+                "executable if it is stale or broken."
+            ),
+        )
+        for version in versions
+        if version.error
+    ]
 
 
 def _check_active_env_python_mismatch(

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -47,8 +47,6 @@ PYTHON_ENVIRONMENT_VARIABLES = (
 
 VIRTUALENV_WRAPPER_MARKERS = ("POETRY_ACTIVE", "PIPENV_ACTIVE")
 SHADOWED_EXECUTABLES = (
-    "python",
-    "python3",
     "pip",
     "pip3",
     "conda",

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Mapping
+from typing import Any, Mapping
 
 CONDA_DISTRIBUTIONS = {
     "anaconda": ("anaconda3", "anaconda"),
@@ -56,6 +56,7 @@ SHADOWED_EXECUTABLES = (
     "micromamba",
     "uv",
 )
+SHADOWED_VERSION_STYLE = "bold cyan"
 VERSION_PROBE_TIMEOUT_SECONDS = 2
 CONDA_ROOT_PATTERN = re.compile(
     r"(?P<root>(?:~|\$HOME|\$\{HOME\}|[A-Za-z]:[/\\]|[/\\])[^\"':;$()]*?)"
@@ -262,10 +263,63 @@ def _print_doctor_report_with_rich(report: DoctorReport) -> None:
             text.append("  Code:", style="bold cyan")
             text.append(f" {finding.code}\n")
             text.append("  Details:", style="bold")
-            text.append(f" {finding.details}\n")
+            _append_rich_details(text, finding)
             text.append("  Recommendation:", style="bold green")
             text.append(f" {finding.recommendation}")
     console.print(text)
+
+
+def _append_rich_details(text: Any, finding: DoctorFinding) -> None:
+    text.append(" ")
+    if not finding.code.startswith("shadowed-"):
+        text.append(f"{finding.details}\n")
+        return
+
+    position = 0
+    for start, end in _shadowed_version_spans(finding.details):
+        if start > position:
+            text.append(finding.details[position:start])
+        text.append(finding.details[start:end], style=SHADOWED_VERSION_STYLE)
+        position = end
+    text.append(f"{finding.details[position:]}\n")
+
+
+def _shadowed_version_spans(details: str) -> list[tuple[int, int]]:
+    spans = []
+    position = 0
+    while True:
+        open_index = details.find(" (", position)
+        if open_index == -1:
+            break
+        start = open_index + 1
+        end = _matching_closing_parenthesis(details, start)
+        if end is None:
+            position = start + 1
+            continue
+        version_text = details[start + 1 : end]
+        if _looks_like_tool_version(version_text):
+            spans.append((start, end + 1))
+        position = end + 1
+    return spans
+
+
+def _matching_closing_parenthesis(text: str, start: int) -> int | None:
+    depth = 0
+    for index, character in enumerate(text[start:], start=start):
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _looks_like_tool_version(text: str) -> bool:
+    normalized = text.casefold()
+    return any(
+        normalized.startswith(f"{executable} ") for executable in SHADOWED_EXECUTABLES
+    )
 
 
 def _finding_level_style(finding: DoctorFinding) -> str:


### PR DESCRIPTION
## Summary
- include `uv` in `unidep doctor` PATH shadowing diagnostics
- show `--version` output next to shadowed environment-tool paths when available
- style shadowed tool version fragments in Rich output while keeping plain text and JSON unchanged
- warn when a discovered tool exists but `tool --version` fails or times out
- avoid noisy `python`/`python3` shadowing info when PATH also contains normal fallback interpreters; interpreter mismatches still warn through dedicated checks
- avoid noisy `pip`/`pip3` shadowing info when the first pip on PATH belongs to the running Python environment
- document the doctor PATH shadowing version context in CLI help and README

## Test Plan
- `.venv/bin/python -m pytest tests/test_doctor.py -q --no-cov`
- `uvx ruff==0.9.9 check unidep/_doctor.py unidep/_cli.py tests/test_doctor.py`
- `uvx ruff==0.9.9 format --check unidep/_doctor.py unidep/_cli.py tests/test_doctor.py`
- `PATH=/home/basnijholt/Code/unidep/.venv/bin:$PATH CONDA_PREFIX=/home/basnijholt/Code/unidep/.venv CONDA_SHLVL=1 .venv/bin/python -m pytest`
- `PATH=/home/basnijholt/Code/unidep/.venv/bin:$PATH .venv/bin/python -c 'from unidep._cli import main; main()' doctor`
- one-off Docker experiment with Miniconda latest, old Conda 4.12.0 under an Anaconda-style root, micromamba 2.6.0, Poetry 1.8.3, pyenv 2.6.30, and duplicate uv/pip installs
  - messy shell profile correctly reported multiple Conda-like initializers and roots
  - messy active env correctly reported stacked Conda envs, mixed managers, interpreter mismatches, and duplicate pip/conda/uv versions
  - clean venv with system Python and pip fallbacks on PATH reported no issues
