### PR TITLE
Detect uninitialized local submodules in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1488,8 +1488,8 @@ options:
 
 ### `unidep doctor`
 
-Use `unidep doctor` to run read-only diagnostics for common Python and Conda environment issues.
-It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, and PATH shadowing for environment tools with version context.
+Use `unidep doctor` to run read-only diagnostics for common Python and Conda environment issues and project-local dependency issues.
+It checks shell startup files, stale Conda/Mamba install roots, active environment variables, interpreter/environment mismatches, Homebrew Python inside Conda environments, PATH shadowing for environment tools with version context, and local dependencies that appear to be uninitialized Git submodules.
 See `unidep doctor -h` for more information:
 
 <!-- CODE:BASH:START -->
@@ -1506,7 +1506,8 @@ Run read-only diagnostics for common Python and Conda environment issues,
 including stacked environments, shell startup conflicts such as stale
 Conda/Mamba install roots, interpreter/environment mismatches, Homebrew Python
 inside Conda environments, and PATH shadowing for environment tools with
-version context.
+version context. Also check project local dependencies for uninitialized Git
+submodules.
 
 options:
   -h, --help  show this help message and exit

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1082,6 +1082,40 @@ def test_rich_report_styles_shadowed_tool_versions(
     assert "('(uv 0.4.0)', 'bold cyan')" in captured.out
 
 
+def test_rich_report_styles_recommendation_inline_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    report = DoctorReport(
+        (
+            DoctorFinding(
+                code="uninitialized-local-git-submodule",
+                level="error",
+                title="A local dependency appears to be an uninitialized Git submodule.",
+                details="requirements.yaml: ./vendor -> /project/vendor",
+                recommendation=(
+                    "Fetch the submodule with "
+                    "`git submodule update --init --recursive`, then rerun "
+                    "`unidep doctor`."
+                ),
+            ),
+        ),
+    )
+    expected_report = format_doctor_report(report)
+    saved_modules = _install_fake_rich(tmp_path, monkeypatch)
+    try:
+        print_doctor_report(report)
+
+        captured = capsys.readouterr()
+    finally:
+        _restore_rich_modules(saved_modules)
+
+    assert captured.out.startswith(f"RICH:{expected_report}\nSTYLES:")
+    assert "('git submodule update --init --recursive', 'bold cyan')" in captured.out
+    assert "('unidep doctor', 'bold cyan')" in captured.out
+
+
 def test_shadowed_version_spans_ignores_unclosed_version() -> None:
     assert _shadowed_version_spans("/first/uv (uv 0.8.1") == []
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import sys
 import textwrap
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from unidep._doctor import (
     DoctorFinding,
@@ -1172,3 +1172,196 @@ def test_path_scan_ignores_duplicate_resolved_executables(tmp_path: Path) -> Non
     )
 
     assert report.finding_by_code("shadowed-python") is None
+
+
+def test_doctor_reports_local_dependency_git_submodule(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    vendor = project / "vendor"
+    vendor.mkdir()
+    (project / ".gitmodules").write_text(
+        textwrap.dedent(
+            """\
+            [submodule "vendor"]
+                path = vendor
+                url = https://example.invalid/vendor.git
+            """,
+        ),
+    )
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - ./vendor
+            """,
+        ),
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    finding = report.finding_by_code("uninitialized-local-git-submodule")
+    assert finding is not None
+    assert finding.level == "error"
+    assert "requirements.yaml" in finding.details
+    assert "./vendor" in finding.details
+    assert "git submodule update --init --recursive" in finding.recommendation
+
+
+def test_doctor_reports_missing_registered_local_dependency_submodule(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".gitmodules").write_text(
+        textwrap.dedent(
+            """\
+            [submodule "vendor"]
+                path = vendor
+                url = https://example.invalid/vendor.git
+            """,
+        ),
+    )
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - ./vendor
+            """,
+        ),
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    assert report.finding_by_code("uninitialized-local-git-submodule") is not None
+
+
+def test_doctor_reports_git_file_only_local_dependency_submodule(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    vendor = project / "vendor"
+    vendor.mkdir()
+    (vendor / ".git").write_text("gitdir: ../.git/modules/vendor")
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - ./vendor
+            """,
+        ),
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    assert report.finding_by_code("uninitialized-local-git-submodule") is not None
+
+
+def test_doctor_ignores_healthy_and_nonlocal_local_dependencies(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    vendor = project / "vendor"
+    vendor.mkdir()
+    (vendor / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+    local_file = project / "local.txt"
+    local_file.write_text("not a directory")
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - ./vendor
+              - ./local.txt
+              - local: ./vendor
+                pypi: vendor-package
+                use: pypi
+            """,
+        ),
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    assert report.finding_by_code("uninitialized-local-git-submodule") is None
+
+
+def test_doctor_warns_when_local_dependency_scan_fails(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - 42
+            """,
+        ),
+    )
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    finding = report.finding_by_code("project-local-dependency-scan-failed")
+    assert finding is not None
+    assert finding.level == "warning"
+    assert "Invalid local dependency format" in finding.details
+
+
+def test_doctor_ignores_unreadable_gitmodules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    vendor = project / "vendor"
+    vendor.mkdir()
+    gitmodules = project / ".gitmodules"
+    gitmodules.write_text("path = vendor\n")
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            local_dependencies:
+              - ./vendor
+            """,
+        ),
+    )
+    original_read_text = type(project).read_text
+
+    def read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == gitmodules:
+            raise OSError
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(project), "read_text", read_text)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        project_dir=project,
+    )
+
+    assert report.finding_by_code("uninitialized-local-git-submodule") is None

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1114,6 +1114,36 @@ def test_rich_report_styles_recommendation_inline_commands(
     assert captured.out.startswith(f"RICH:{expected_report}\nSTYLES:")
     assert "('git submodule update --init --recursive', 'bold cyan')" in captured.out
     assert "('unidep doctor', 'bold cyan')" in captured.out
+    assert "('`, then rerun `', 'bold cyan')" not in captured.out
+
+
+def test_rich_report_leaves_unclosed_recommendation_backtick_unstyled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    report = DoctorReport(
+        (
+            DoctorFinding(
+                code="example",
+                level="warning",
+                title="A warning finding.",
+                details="details",
+                recommendation="Inspect `unterminated command manually.",
+            ),
+        ),
+    )
+    expected_report = format_doctor_report(report)
+    saved_modules = _install_fake_rich(tmp_path, monkeypatch)
+    try:
+        print_doctor_report(report)
+
+        captured = capsys.readouterr()
+    finally:
+        _restore_rich_modules(saved_modules)
+
+    assert captured.out.startswith(f"RICH:{expected_report}\nSTYLES:")
+    assert "unterminated command" not in captured.out.split("STYLES:", maxsplit=1)[1]
 
 
 def test_shadowed_version_spans_ignores_unclosed_version() -> None:

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -749,7 +749,8 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "issues, including stacked environments, shell startup conflicts "
             "such as stale Conda/Mamba install roots, interpreter/environment "
             "mismatches, Homebrew Python inside Conda environments, and PATH "
-            "shadowing for environment tools with version context."
+            "shadowing for environment tools with version context. Also check "
+            "project local dependencies for uninitialized Git submodules."
         ),
         formatter_class=_HelpFormatter,
     )

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -13,6 +13,15 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+from ruamel.yaml import YAML
+
+from unidep._dependencies_parsing import (
+    _load,
+    find_requirements_files,
+    get_local_dependencies,
+)
+from unidep.utils import split_path_and_extras
+
 CONDA_DISTRIBUTIONS = {
     "anaconda": ("anaconda3", "anaconda"),
     "miniconda": ("miniconda3", "miniconda"),
@@ -161,6 +170,7 @@ def run_doctor_command(
     env: Mapping[str, str] | None = None,
     path_env: str | None = None,
     python_executable: str | None = None,
+    project_dir: Path | None = None,
     output_format: str = "text",
     strict: bool = False,
 ) -> int:
@@ -170,6 +180,7 @@ def run_doctor_command(
         env=env,
         path_env=path_env,
         python_executable=python_executable,
+        project_dir=Path.cwd() if project_dir is None else project_dir,
     )
     if output_format == "json":
         print(format_doctor_report_json(report))
@@ -184,6 +195,7 @@ def run_doctor_checks(
     env: Mapping[str, str] | None = None,
     path_env: str | None = None,
     python_executable: str | None = None,
+    project_dir: Path | None = None,
 ) -> DoctorReport:
     """Collect read-only diagnostics for the current Python environment."""
     resolved_home = Path.home() if home is None else home
@@ -199,6 +211,7 @@ def run_doctor_checks(
             path_env=resolved_path,
             python_executable=resolved_python,
         ),
+        *(_check_project_local_dependencies(project_dir) if project_dir else []),
     ]
     return DoctorReport(tuple(findings))
 
@@ -691,6 +704,97 @@ def _check_path(
                 ),
             )
     return findings
+
+
+def _check_project_local_dependencies(project_dir: Path) -> list[DoctorFinding]:
+    findings = []
+    project_path = project_dir.resolve()
+    gitmodule_paths = _gitmodule_paths(project_path)
+    yaml = YAML(typ="safe")
+    for requirements_file in find_requirements_files(project_path, depth=1):
+        try:
+            data = _load(requirements_file, yaml)
+            local_dependencies = get_local_dependencies(data)
+        except (OSError, KeyError, TypeError, ValueError) as error:
+            findings.append(
+                DoctorFinding(
+                    code="project-local-dependency-scan-failed",
+                    level="warning",
+                    title="A UniDep dependency file could not be checked.",
+                    details=f"{requirements_file}: {error}",
+                    recommendation=(
+                        "Inspect the dependency file manually or run the relevant "
+                        "`unidep` command for the full parser error."
+                    ),
+                ),
+            )
+            continue
+
+        for local_dependency in local_dependencies:
+            if local_dependency.use != "local":
+                continue
+            local_path, _extras = split_path_and_extras(local_dependency.local)
+            dependency_path = (requirements_file.parent / local_path).resolve()
+            if not _local_dependency_is_uninitialized_submodule(
+                dependency_path,
+                gitmodule_paths,
+            ):
+                continue
+            findings.append(
+                DoctorFinding(
+                    code="uninitialized-local-git-submodule",
+                    level="error",
+                    title=(
+                        "A local dependency appears to be an uninitialized "
+                        "Git submodule."
+                    ),
+                    details=(
+                        f"{requirements_file}: {local_dependency.local} -> "
+                        f"{dependency_path}"
+                    ),
+                    recommendation=(
+                        "Fetch the submodule with "
+                        "`git submodule update --init --recursive`, then rerun "
+                        "`unidep doctor`."
+                    ),
+                ),
+            )
+    return findings
+
+
+def _gitmodule_paths(project_dir: Path) -> set[Path]:
+    gitmodules = project_dir / ".gitmodules"
+    if not gitmodules.is_file():
+        return set()
+    paths: set[Path] = set()
+    try:
+        lines = gitmodules.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return paths
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "path":
+            paths.add((project_dir / value.strip()).resolve())
+    return paths
+
+
+def _local_dependency_is_uninitialized_submodule(
+    dependency_path: Path,
+    gitmodule_paths: set[Path],
+) -> bool:
+    is_registered_submodule = dependency_path in gitmodule_paths
+    if not dependency_path.exists():
+        return is_registered_submodule
+    if not dependency_path.is_dir():
+        return False
+    if _is_empty_git_submodule_checkout(dependency_path):
+        return True
+    return is_registered_submodule and not any(dependency_path.iterdir())
+
+
+def _is_empty_git_submodule_checkout(path: Path) -> bool:
+    git_file = path / ".git"
+    return git_file.is_file() and len(list(path.iterdir())) == 1
 
 
 def _first_match_is_expected_pip(

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -309,7 +309,8 @@ def _append_rich_inline_commands(text: Any, value: str) -> None:
             return
         text.append(value[position : start + 1])
         text.append(value[start + 1 : end], style=INLINE_COMMAND_STYLE)
-        position = end
+        text.append("`")
+        position = end + 1
 
 
 def _shadowed_version_spans(details: str) -> list[tuple[int, int]]:

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -64,6 +64,7 @@ SHADOWED_EXECUTABLES = (
     "uv",
 )
 SHADOWED_VERSION_STYLE = "bold cyan"
+INLINE_COMMAND_STYLE = "bold cyan"
 VERSION_PROBE_TIMEOUT_SECONDS = 2
 CONDA_ROOT_PATTERN = re.compile(
     r"(?P<root>(?:~|\$HOME|\$\{HOME\}|[A-Za-z]:[/\\]|[/\\])[^\"':;$()]*?)"
@@ -276,7 +277,7 @@ def _print_doctor_report_with_rich(report: DoctorReport) -> None:
             text.append("  Details:", style="bold")
             _append_rich_details(text, finding)
             text.append("  Recommendation:", style="bold green")
-            text.append(f" {finding.recommendation}")
+            _append_rich_inline_commands(text, f" {finding.recommendation}")
     console.print(text)
 
 
@@ -293,6 +294,22 @@ def _append_rich_details(text: Any, finding: DoctorFinding) -> None:
         text.append(finding.details[start:end], style=SHADOWED_VERSION_STYLE)
         position = end
     text.append(f"{finding.details[position:]}\n")
+
+
+def _append_rich_inline_commands(text: Any, value: str) -> None:
+    position = 0
+    while True:
+        start = value.find("`", position)
+        if start == -1:
+            text.append(value[position:])
+            return
+        end = value.find("`", start + 1)
+        if end == -1:
+            text.append(value[position:])
+            return
+        text.append(value[position : start + 1])
+        text.append(value[start + 1 : end], style=INLINE_COMMAND_STYLE)
+        position = end
 
 
 def _shadowed_version_spans(details: str) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Summary
- Add a read-only `unidep doctor` project scan for `local_dependencies` that look like uninitialized Git submodules.
- Detect missing registered submodule paths, empty registered submodule directories, and `.git`-file-only submodule checkouts.
- Style only backtick-delimited inline commands in Rich recommendation output and update doctor help text / README docs for the new diagnostic.

## Test Plan
- `uv run pytest tests/test_doctor.py -q --cov=unidep._doctor --cov-report=term-missing --cov-fail-under=100 -o addopts=''` (61 passed, 100% `_doctor.py` coverage)
- `uv run ruff check unidep/_doctor.py tests/test_doctor.py`
- commit hook: ruff, ruff-format, mypy
