### PR TITLE
Fix doctor warnings for uv tool installs

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -571,6 +571,124 @@ def test_path_scan_reports_path_python_mismatch(tmp_path: Path) -> None:
     assert str(running_python) in finding.details
 
 
+def test_path_scan_treats_uv_tool_python_as_isolated_runtime(
+    tmp_path: Path,
+) -> None:
+    virtual_env = tmp_path / "project" / ".venv"
+    path_python = virtual_env / "bin" / "python"
+    path_python3 = virtual_env / "bin" / "python3"
+    uv_tool_python = (
+        tmp_path / ".local" / "share" / "uv" / "tools" / "unidep" / "bin" / "python3"
+    )
+    _make_executable(path_python)
+    _make_executable(path_python3)
+    _make_executable(uv_tool_python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={"VIRTUAL_ENV": str(virtual_env)},
+        path_env=str(path_python.parent),
+        python_executable=str(uv_tool_python),
+    )
+
+    assert report.finding_by_code("virtual-env-python-mismatch") is None
+    assert report.finding_by_code("path-python-mismatch") is None
+    assert report.finding_by_code("path-python3-mismatch") is None
+
+    finding = report.finding_by_code("uv-tool-python-runtime")
+    assert finding is not None
+    assert finding.level == "info"
+    assert str(virtual_env) in finding.details
+    assert str(uv_tool_python) in finding.details
+
+
+def test_path_scan_reports_uv_tool_runtime_without_active_environment(
+    tmp_path: Path,
+) -> None:
+    uv_tool_python = (
+        tmp_path / ".local" / "share" / "uv" / "tools" / "unidep" / "bin" / "python3"
+    )
+    _make_executable(uv_tool_python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        python_executable=str(uv_tool_python),
+    )
+
+    finding = report.finding_by_code("uv-tool-python-runtime")
+    assert finding is not None
+    assert finding.level == "info"
+    assert str(uv_tool_python) in finding.details
+    assert "active environment markers" not in finding.details
+
+
+def test_path_scan_detects_uv_tool_dir_override(tmp_path: Path) -> None:
+    uv_tool_dir = tmp_path / "custom-tools"
+    uv_tool_python = uv_tool_dir / "unidep" / "bin" / "python3"
+    _make_executable(uv_tool_python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={"UV_TOOL_DIR": str(uv_tool_dir)},
+        path_env="",
+        python_executable=str(uv_tool_python),
+    )
+
+    assert report.finding_by_code("uv-tool-python-runtime") is not None
+
+
+def test_path_scan_detects_xdg_uv_tool_directory(tmp_path: Path) -> None:
+    xdg_data_home = tmp_path / "xdg-data"
+    uv_tool_python = xdg_data_home / "uv" / "tools" / "unidep" / "bin" / "python3"
+    _make_executable(uv_tool_python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={"XDG_DATA_HOME": str(xdg_data_home)},
+        path_env="",
+        python_executable=str(uv_tool_python),
+    )
+
+    assert report.finding_by_code("uv-tool-python-runtime") is not None
+
+
+def test_path_scan_detects_windows_uv_tool_directory(tmp_path: Path) -> None:
+    appdata = tmp_path / "AppData" / "Roaming"
+    uv_tool_python = (
+        appdata / "uv" / "data" / "tools" / "unidep" / "Scripts" / "python.exe"
+    )
+    _make_executable(uv_tool_python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={"APPDATA": str(appdata)},
+        path_env="",
+        python_executable=str(uv_tool_python),
+    )
+
+    assert report.finding_by_code("uv-tool-python-runtime") is not None
+
+
+def test_path_scan_does_not_treat_other_uv_paths_as_tool_runtime(
+    tmp_path: Path,
+) -> None:
+    python = (
+        tmp_path / ".local" / "share" / "uv" / "tools" / "unidep" / "not-bin" / "python"
+    )
+    _make_executable(python)
+
+    report = run_doctor_checks(
+        home=tmp_path,
+        env={},
+        path_env="",
+        python_executable=str(python),
+    )
+
+    assert report.finding_by_code("uv-tool-python-runtime") is None
+
+
 def test_path_scan_reports_symlinked_virtualenv_python_mismatch(
     tmp_path: Path,
 ) -> None:

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -209,6 +209,7 @@ def run_doctor_checks(
         *_check_active_environment(resolved_env),
         *_check_path(
             env=resolved_env,
+            home=resolved_home,
             path_env=resolved_path,
             python_executable=resolved_python,
         ),
@@ -672,19 +673,23 @@ def _active_conda_prefixes(env: Mapping[str, str]) -> list[str]:
 def _check_path(
     *,
     env: Mapping[str, str],
+    home: Path,
     path_env: str,
     python_executable: str,
 ) -> list[DoctorFinding]:
     findings = []
     python_path = Path(python_executable)
-    findings.extend(_check_active_env_python_mismatch(env, python_path))
-    findings.extend(
-        _check_path_python_mismatch(
-            path_env=path_env,
-            path_extensions=env.get("PATHEXT"),
-            python_executable=python_path,
-        ),
-    )
+    if _is_uv_tool_python(python_path, env=env, home=home):
+        findings.append(_uv_tool_python_runtime_finding(env, python_path))
+    else:
+        findings.extend(_check_active_env_python_mismatch(env, python_path))
+        findings.extend(
+            _check_path_python_mismatch(
+                path_env=path_env,
+                path_extensions=env.get("PATHEXT"),
+                python_executable=python_path,
+            ),
+        )
 
     if env.get("CONDA_PREFIX") and _is_homebrew_python(python_path):
         findings.append(
@@ -861,6 +866,29 @@ def _first_nonempty_line(output: str | None) -> str | None:
     return next((line.strip() for line in output.splitlines() if line.strip()), None)
 
 
+def _uv_tool_python_runtime_finding(
+    env: Mapping[str, str],
+    python_executable: Path,
+) -> DoctorFinding:
+    active_markers = _active_python_environment_markers(env)
+    active_context = (
+        f"active environment markers: {', '.join(active_markers)}; "
+        if active_markers
+        else ""
+    )
+    return DoctorFinding(
+        code="uv-tool-python-runtime",
+        level="info",
+        title="UniDep is running from an isolated uv tool environment.",
+        details=f"{active_context}UniDep runtime: {python_executable}",
+        recommendation=(
+            "This is normal for `uv tool install unidep`. For mutating commands, "
+            "run UniDep from the environment you intend to modify or pass an "
+            "explicit target environment option when available."
+        ),
+    )
+
+
 def _version_probe_findings(
     executable: str,
     versions: list[_ExecutableVersion],
@@ -955,6 +983,34 @@ def _check_path_python_mismatch(
 def _is_homebrew_python(path: Path) -> bool:
     normalized = path.resolve(strict=False).as_posix().lower()
     return "/homebrew/" in normalized or "/cellar/python" in normalized
+
+
+def _is_uv_tool_python(path: Path, *, env: Mapping[str, str], home: Path) -> bool:
+    executable_name = _normalized_executable_name(path)
+    if not executable_name.startswith("python"):
+        return False
+    if path.parent.name.lower() not in {"bin", "scripts"}:
+        return False
+    tool_environment = path.parent.parent
+    for tools_dir in _uv_tool_directories(env, home):
+        if _same_path(tool_environment.parent, tools_dir):
+            return True
+    return False
+
+
+def _uv_tool_directories(env: Mapping[str, str], home: Path) -> tuple[Path, ...]:
+    if env.get("UV_TOOL_DIR"):
+        return (Path(env["UV_TOOL_DIR"]),)
+
+    tool_directories = []
+    if env.get("XDG_DATA_HOME"):
+        tool_directories.append(Path(env["XDG_DATA_HOME"]) / "uv" / "tools")
+    else:
+        tool_directories.append(home / ".local" / "share" / "uv" / "tools")
+
+    if env.get("APPDATA"):
+        tool_directories.append(Path(env["APPDATA"]) / "uv" / "data" / "tools")
+    return tuple(tool_directories)
 
 
 def _path_is_inside(path: Path, prefix: Path) -> bool:


### PR DESCRIPTION
## Summary
- Detect UniDep running from a `uv tool` Python runtime in `doctor`.
- Replace generic active-env/path Python mismatch warnings with a single informational finding.
- Add regression coverage for active virtualenv, no active environment, and non-tool uv paths.

## Test Plan
- `uv run --extra test pytest tests/test_doctor.py --no-cov`
- `CONDA_PREFIX=/Users/bas.nijholt/.codex/worktrees/e5f0/unidep/.venv uv run --extra test pytest`
- `uvx ruff check unidep/_doctor.py tests/test_doctor.py`

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--299.org.readthedocs.build/en/299/

<!-- readthedocs-preview unidep end -->