### PR TITLE
Fix pixi URL dependency output

### DIFF
--- a/tests/test_pixi.py
+++ b/tests/test_pixi.py
@@ -410,6 +410,31 @@ def test_pixi_normalizes_single_equals_for_pip_pins(tmp_path: Path) -> None:
     assert data["pypi-dependencies"]["pygsti"] == "==0.9.13.3"
 
 
+def test_pixi_direct_url_pypi_dependency_uses_url_table(tmp_path: Path) -> None:
+    """Direct URL PyPI dependencies must use Pixi's table syntax."""
+    url = "https://files.pythonhosted.org/packages/example/pyqir.whl#sha256=abc"
+    req_file = _write_file(
+        tmp_path / "requirements.yaml",
+        f"""\
+        dependencies:
+          - pip: pyqir @ {url}:linux64
+        platforms:
+          - linux-64
+          - osx-arm64
+        """,
+    )
+
+    data = _generate_and_load(
+        tmp_path / "pixi.toml",
+        req_file,
+    )
+
+    assert data["target"]["linux-64"]["pypi-dependencies"]["pyqir"] == {
+        "url": url,
+    }
+    assert "osx-arm64" not in data.get("target", {})
+
+
 def test_pixi_prefers_pip_pin_over_unpinned_conda(tmp_path: Path) -> None:
     """Pinned pip spec should override unpinned conda spec."""
     req_file = _write_file(

--- a/unidep/_pixi.py
+++ b/unidep/_pixi.py
@@ -117,6 +117,15 @@ def _parse_package_extras(pkg_name: str) -> tuple[str, list[str]]:
     return pkg_name, []
 
 
+def _direct_url_from_pip_version(version: str) -> str | None:
+    """Return a Pixi direct URL from a PEP 508 URL pin."""
+    stripped = version.strip()
+    if not stripped.startswith("@"):
+        return None
+    url = stripped[1:].strip()
+    return url if url.startswith(("http://", "https://", "file://")) else None
+
+
 def _make_pip_version_spec(
     version: str | dict[str, str],
     extras: list[str],
@@ -131,6 +140,11 @@ def _make_pip_version_spec(
         dict: Table with version and extras if extras present
 
     """
+    if isinstance(version, str):
+        direct_url = _direct_url_from_pip_version(version)
+        if direct_url is not None:
+            return {"url": direct_url, **({"extras": extras} if extras else {})}
+
     if not extras:
         return version
 


### PR DESCRIPTION
## Summary
- emit Pixi URL dependency tables for PEP 508 direct HTTP(S)/file PyPI pins
- add regression coverage for platform-specific direct URL dependencies

## Tests
- env PATH="$PWD/.venv/bin:$PATH" CONDA_PREFIX="$PWD/.venv" .venv/bin/python -m pytest --no-cov
- env PATH="$PWD/.venv/bin:$PATH" CONDA_PREFIX="$PWD/.venv" .venv/bin/python -m pytest (tests passed; local coverage gate failed at 99.97% due unrelated unidep/_cli.py:804 not covered when no conda executable is on PATH)
- pre-commit hooks via git commit

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview unidep end -->