### PR TITLE
Add Rich install output

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -110,10 +110,13 @@ Using `unidep` for installation offers a more comprehensive approach. It handles
 $ unidep install --dry-run -e ./setup_py_project
 📝 Found local dependencies: {'setup_py_project': ['hatch_project', 'setuptools_project']}
 
+◆ Installing conda dependencies...
 📦 Installing conda dependencies with `conda install --yes --override-channels --channel conda-forge adaptive">=0.15.0, <2.0.0" adaptive-scheduler hpc05 pexpect pfapack numpy">=1.21" packaging pandas">=1,<3" pytest pytest-cov pip`
 
+◆ Installing pip dependencies...
 📦 Installing pip dependencies with `/opt/hostedtoolcache/Python/3.14.2/x64/bin/python -m pip install yaml2bib aiokef markdown-code-runner numthreads pyyaml rsync-time-machine slurm-usage unidep`
 
+◆ Installing project...
 📦 Installing project with `/opt/hostedtoolcache/Python/3.14.2/x64/bin/python -m pip install --no-deps -e /home/runner/work/unidep/unidep/example/hatch_project -e /home/runner/work/unidep/unidep/example/setuptools_project -e ./setup_py_project`
 
 ```
@@ -157,10 +160,13 @@ unidep install-all -e
 $ unidep install-all -e --dry-run
 📝 Found local dependencies: {'pyproject_toml_project': ['hatch_project'], 'setup_py_project': ['hatch_project', 'setuptools_project'], 'setuptools_project': ['hatch_project']}
 
+◆ Installing conda dependencies...
 📦 Installing conda dependencies with `conda install --yes --override-channels --channel conda-forge adaptive">=0.15.0, <2.0.0" adaptive-scheduler hpc05 pexpect pfapack numpy">=1.21" packaging pandas">=1,<3" pytest pytest-cov pip`
 
+◆ Installing pip dependencies...
 📦 Installing pip dependencies with `/opt/hostedtoolcache/Python/3.14.2/x64/bin/python -m pip install yaml2bib aiokef markdown-code-runner numthreads pyyaml rsync-time-machine slurm-usage unidep`
 
+◆ Installing project...
 📦 Installing project with `/opt/hostedtoolcache/Python/3.14.2/x64/bin/python -m pip install --no-deps -e ./hatch2_project -e ./hatch_project -e ./pyproject_toml_project -e ./setup_py_project -e ./setuptools_project`
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ toml = ["tomli; python_version < '3.11'"]
 conda-lock = ["conda-lock", "conda-package-handling"]
 pip-compile = ["pip-tools"]
 pytest = ["pytest", "GitPython"] # The pytest plugin
-rich = ["rich-argparse"]
+rich = ["rich", "rich-argparse"]
 pixi = ["pixi-to-conda-lock", "tomli_w"]
 # Everything except 'test' and 'docs'
 all = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import sys
 import textwrap
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -45,9 +45,13 @@ from unidep._cli import (
     _pip_compile_command,
     _pip_subcommand,
     _print_versions,
+    _print_with_rich,
     main,
 )
 from unidep._dependencies_parsing import parse_requirements
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -126,8 +130,11 @@ def test_unidep_install_dry_run(project: str) -> None:
     # Check the output
     assert result.returncode == 0, "Command failed to execute successfully"
     if project in ("setup_py_project", "setuptools_project"):
+        assert "◆ Installing conda dependencies..." in result.stdout
         assert "📦 Installing conda dependencies with" in result.stdout
+    assert "◆ Installing pip dependencies..." in result.stdout
     assert "📦 Installing pip dependencies with" in result.stdout
+    assert "◆ Installing project..." in result.stdout
     assert "📦 Installing project with" in result.stdout
 
 
@@ -144,11 +151,50 @@ def test_install_all_command(capsys: pytest.CaptureFixture) -> None:
         verbose=False,
     )
     captured = capsys.readouterr()
+    assert "◆ Installing conda dependencies..." in captured.out
     assert "Installing conda dependencies" in captured.out
+    assert "◆ Installing pip dependencies..." in captured.out
     assert "Installing pip dependencies" in captured.out
+    assert "◆ Installing project..." in captured.out
     projects = [REPO_ROOT / "example" / p for p in EXAMPLE_PROJECTS]
     pkgs = " ".join([f"-e {p}" for p in sorted(projects)])
     assert f"pip install --no-deps {pkgs}`" in captured.out
+
+
+def test_install_command_prints_phase_before_command_when_running_pip(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "requirements.yaml").write_text(
+        textwrap.dedent(
+            """\
+            dependencies:
+              - pip: markdown-code-runner
+            """,
+        ),
+    )
+
+    with patch("unidep._cli.subprocess.run"):
+        _install_command(
+            project,
+            conda_executable="micromamba",
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_conda=True,
+            no_uv=True,
+            verbose=False,
+        )
+
+    output = capsys.readouterr().out
+    assert output.index("◆ Installing pip dependencies...") < output.index(
+        "📦 Installing pip dependencies with",
+    )
 
 
 def test_install_command_installs_pip_when_target_env_needs_pip(
@@ -168,12 +214,16 @@ def test_install_command_installs_pip_when_target_env_needs_pip(
         ),
     )
 
-    with patch("unidep._cli._get_conda_executable", return_value="micromamba"), patch(
-        "unidep._cli._maybe_create_conda_env_args",
-        return_value=["--name", "new-env"],
-    ), patch(
-        "unidep._cli._python_executable",
-        return_value="/opt/micromamba/envs/new-env/bin/python",
+    with (
+        patch("unidep._cli._get_conda_executable", return_value="micromamba"),
+        patch(
+            "unidep._cli._maybe_create_conda_env_args",
+            return_value=["--name", "new-env"],
+        ),
+        patch(
+            "unidep._cli._python_executable",
+            return_value="/opt/micromamba/envs/new-env/bin/python",
+        ),
     ):
         _install_command(
             project,
@@ -189,6 +239,7 @@ def test_install_command_installs_pip_when_target_env_needs_pip(
         )
 
     output = capsys.readouterr().out
+    assert "◆ Installing conda dependencies..." in output
     assert re.search(
         r"Installing conda dependencies with `.*install --yes --override-channels "
         r"--channel conda-forge --name new-env pip`",
@@ -219,12 +270,16 @@ def test_install_command_does_not_install_pip_without_pip_operations(
         ),
     )
 
-    with patch("unidep._cli._get_conda_executable", return_value="micromamba"), patch(
-        "unidep._cli._maybe_create_conda_env_args",
-        return_value=["--name", "new-env"],
-    ), patch(
-        "unidep._cli._python_executable",
-        return_value="/opt/micromamba/envs/new-env/bin/python",
+    with (
+        patch("unidep._cli._get_conda_executable", return_value="micromamba"),
+        patch(
+            "unidep._cli._maybe_create_conda_env_args",
+            return_value=["--name", "new-env"],
+        ),
+        patch(
+            "unidep._cli._python_executable",
+            return_value="/opt/micromamba/envs/new-env/bin/python",
+        ),
     ):
         _install_command(
             project,
@@ -266,12 +321,16 @@ def test_install_command_installs_pip_when_local_project_needs_pip(
         ),
     )
 
-    with patch("unidep._cli._get_conda_executable", return_value="micromamba"), patch(
-        "unidep._cli._maybe_create_conda_env_args",
-        return_value=["--name", "new-env"],
-    ), patch(
-        "unidep._cli._python_executable",
-        return_value="/opt/micromamba/envs/new-env/bin/python",
+    with (
+        patch("unidep._cli._get_conda_executable", return_value="micromamba"),
+        patch(
+            "unidep._cli._maybe_create_conda_env_args",
+            return_value=["--name", "new-env"],
+        ),
+        patch(
+            "unidep._cli._python_executable",
+            return_value="/opt/micromamba/envs/new-env/bin/python",
+        ),
     ):
         _install_command(
             project,
@@ -1199,9 +1258,12 @@ def test_doubly_nested_project_folder_installable(
 def test_pip_compile_command(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     folder = tmp_path / "example"
     shutil.copytree(REPO_ROOT / "example", folder)
-    with patch("subprocess.run", return_value=None), patch(
-        "importlib.util.find_spec",
-        return_value=True,
+    with (
+        patch("subprocess.run", return_value=None),
+        patch(
+            "importlib.util.find_spec",
+            return_value=True,
+        ),
     ):
         _pip_compile_command(
             depth=2,
@@ -1327,10 +1389,13 @@ def test_doctor_cli_dispatches_options_and_exit_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["unidep", "doctor", "--json", "--strict"])
-    with patch(
-        "unidep._cli.run_doctor_command",
-        return_value=5,
-    ) as doctor, pytest.raises(SystemExit) as excinfo:
+    with (
+        patch(
+            "unidep._cli.run_doctor_command",
+            return_value=5,
+        ) as doctor,
+        pytest.raises(SystemExit) as excinfo,
+    ):
         main()
 
     assert excinfo.value.code == 5
@@ -1390,10 +1455,13 @@ def test_check_conda_prefix_rejects_sibling_prefix(
     monkeypatch.setenv("CONDA_PREFIX", str(prefix))
     monkeypatch.setattr(sys, "executable", str(python))
 
-    with pytest.warns(
-        UserWarning,
-        match="not in the active Conda environment",
-    ), pytest.raises(SystemExit) as excinfo:
+    with (
+        pytest.warns(
+            UserWarning,
+            match="not in the active Conda environment",
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
         _check_conda_prefix()
 
     assert excinfo.value.code == 1
@@ -1414,10 +1482,13 @@ def test_check_conda_prefix_rejects_uncomparable_paths(
 
     monkeypatch.setattr("unidep._cli.os.path.commonpath", commonpath)
 
-    with pytest.warns(
-        UserWarning,
-        match="not in the active Conda environment",
-    ), pytest.raises(SystemExit) as excinfo:
+    with (
+        pytest.warns(
+            UserWarning,
+            match="not in the active Conda environment",
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
         _check_conda_prefix()
 
     assert excinfo.value.code == 1
@@ -1479,12 +1550,28 @@ def test_unidep_version_uses_rich_when_available(
     monkeypatch.delitem(sys.modules, "rich.console", raising=False)
     monkeypatch.delitem(sys.modules, "rich.table", raising=False)
 
-    _print_versions()
+    try:
+        _print_versions()
+    finally:
+        sys.modules.pop("rich", None)
+        sys.modules.pop("rich.console", None)
+        sys.modules.pop("rich.table", None)
 
     output = capsys.readouterr().out
     assert "RICH:[('Property', 'cyan'), ('Value', 'magenta')]" in output
     assert "('unidep version'," in output
     assert "('packaging version'," in output
+
+
+def test_print_with_rich_falls_back_when_rich_components_are_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr("unidep._cli.rich_class", lambda *_args: None)
+
+    _print_with_rich(["unidep version: 1.2.3", "Python version: 3.11"])
+
+    assert capsys.readouterr().out == "unidep version: 1.2.3\nPython version: 3.11\n"
 
 
 def test_pip_optional(tmp_path: Path) -> None:

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,219 @@
+"""Tests for CLI output rendering helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
+
+from unidep import _cli_output
+from unidep._cli_output import print_command, print_phase
+
+
+def test_install_output_plain_keeps_backtick_command_format(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_cli_output, "_rich_console", lambda: None)
+
+    print_command(
+        "Installing conda dependencies",
+        "micromamba install numpy",
+    )
+
+    captured = capsys.readouterr()
+    assert (
+        "📦 Installing conda dependencies with `micromamba install numpy`"
+        in captured.out
+    )
+
+
+def test_rich_class_returns_none_when_rich_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_find_spec = importlib.util.find_spec
+
+    def find_spec(name: str) -> object | None:
+        if name.startswith("rich"):
+            return None
+        return original_find_spec(name)
+
+    monkeypatch.setattr(_cli_output.importlib.util, "find_spec", find_spec)
+
+    assert _cli_output.rich_class("rich.text", "Text") is None
+
+
+def test_install_output_auto_console_is_disabled_when_stdout_is_not_tty(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_cli_output.sys.stdout, "isatty", lambda: False)
+
+    print_phase("Installing pip dependencies")
+
+    captured = capsys.readouterr()
+    assert "◆ Installing pip dependencies..." in captured.out
+
+
+def test_install_output_auto_console_returns_none_when_rich_console_is_unavailable(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_cli_output.sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(_cli_output, "rich_class", lambda *_args: None)
+
+    print_phase("Installing pip dependencies")
+
+    captured = capsys.readouterr()
+    assert "◆ Installing pip dependencies..." in captured.out
+
+
+def test_install_output_auto_console_uses_rich_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rendered_items: list[tuple[Any, dict[str, Any]]] = []
+
+    class Console:
+        def print(self, rendered: Any, **kwargs: Any) -> None:
+            rendered_items.append((rendered, kwargs))
+
+    class Text:
+        def __init__(self, plain: str = "") -> None:
+            self.plain = plain
+
+        def append(self, text: str, **_kwargs: Any) -> None:
+            self.plain += text
+
+    def rich_class(module_name: str, _class_name: str) -> type[Console | Text]:
+        if module_name == "rich.console":
+            return Console
+        return Text
+
+    monkeypatch.setattr(_cli_output.sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(_cli_output, "rich_class", rich_class)
+
+    print_phase("Installing pip dependencies")
+
+    assert rendered_items
+    rendered, kwargs = rendered_items[0]
+    assert rendered.plain == "◆ Installing pip dependencies..."
+    assert kwargs == {"soft_wrap": True}
+
+
+def test_install_output_falls_back_to_plain_command_without_rich_text(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Console:
+        pass
+
+    monkeypatch.setattr(_cli_output, "_rich_console", Console)
+    monkeypatch.setattr(_cli_output, "rich_class", lambda *_args: None)
+
+    print_command(
+        "Installing pip dependencies",
+        "uv pip install pydantic",
+    )
+
+    captured = capsys.readouterr()
+    assert (
+        "📦 Installing pip dependencies with `uv pip install pydantic`" in captured.out
+    )
+
+
+def test_install_output_rich_styles_exact_command_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Console:
+        def __init__(self) -> None:
+            self.rendered: Any | None = None
+            self.print_kwargs: dict[str, Any] = {}
+
+        def print(self, rendered: Any | None = None, **kwargs: Any) -> None:
+            if rendered is not None:
+                self.rendered = rendered
+                self.print_kwargs = kwargs
+
+    command = (
+        "micromamba install --yes --override-channels --channel conda-forge "
+        'fastapi httpx numpy"<3" pip pydantic python"=3.12.*" sqlalchemy'
+    )
+    console = Console()
+
+    monkeypatch.setattr(_cli_output, "_rich_console", lambda: console)
+
+    print_command("Installing conda dependencies", command)
+
+    assert console.rendered is not None
+    assert console.rendered.plain == f"📦 Installing conda dependencies with {command}"
+    command_start = len("📦 Installing conda dependencies with ")
+    assert [
+        (span.start, span.end, str(span.style)) for span in console.rendered.spans
+    ] == [(command_start, command_start + len(command), "bold cyan")]
+    assert console.print_kwargs == {"soft_wrap": True}
+
+
+def test_install_output_print_phase_prints_colored_line_without_spinner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Console:
+        def __init__(self) -> None:
+            self.status_calls: list[tuple[str, str]] = []
+            self.rendered: list[Any] = []
+            self.print_kwargs: list[dict[str, Any]] = []
+
+        def print(self, rendered: Any | None = None, **kwargs: Any) -> None:
+            if rendered is not None:
+                self.rendered.append(rendered)
+                self.print_kwargs.append(kwargs)
+
+        def status(self, label: str, *, spinner: str) -> None:
+            self.status_calls.append((label, spinner))
+
+    console = Console()
+    monkeypatch.setattr(_cli_output, "_rich_console", lambda: console)
+
+    print_phase("Installing pip dependencies")
+
+    assert console.status_calls == []
+    assert len(console.rendered) == 1
+    rendered = console.rendered[0]
+    assert rendered.plain == "◆ Installing pip dependencies..."
+    assert [(span.start, span.end, str(span.style)) for span in rendered.spans] == [
+        (0, len("◆"), "bold green"),
+        (1, len("◆ Installing pip dependencies..."), "bold yellow"),
+    ]
+    assert console.print_kwargs == [{"soft_wrap": True}]
+
+
+def test_install_output_print_phase_plain_prints_symbol(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_cli_output, "_rich_console", lambda: None)
+
+    print_phase("Installing pip dependencies")
+
+    captured = capsys.readouterr()
+    assert "◆ Installing pip dependencies..." in captured.out
+
+
+def test_install_output_print_phase_falls_back_without_rich_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Console:
+        def __init__(self) -> None:
+            self.rendered: list[str] = []
+
+        def print(self, rendered: str) -> None:
+            self.rendered.append(rendered)
+
+    console = Console()
+    monkeypatch.setattr(_cli_output, "_rich_console", lambda: console)
+    monkeypatch.setattr(_cli_output, "rich_class", lambda *_args: None)
+
+    print_phase("Installing conda dependencies")
+
+    assert console.rendered == ["◆ Installing conda dependencies..."]

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -19,10 +19,11 @@ import sys
 import time
 from importlib import resources as importlib_resources
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast, get_args
 
 from ruamel.yaml import YAML
 
+from unidep._cli_output import print_command, print_phase, rich_class
 from unidep._conda_env import (
     create_conda_env_specification,
     write_conda_environment_file,
@@ -59,11 +60,6 @@ from unidep.utils import (
     resolve_platforms,
     warn,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, get_args
-else:  # pragma: no cover
-    from typing_extensions import Literal, get_args
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -980,13 +976,13 @@ def _conda_cli_command_json(
         raise
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _conda_env_list(conda_executable: CondaExecutable) -> list[str]:
     """Get a list of conda environments."""
     return _conda_cli_command_json(conda_executable, "env", "list")["envs"]
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _conda_info(conda_executable: CondaExecutable) -> dict:
     return _conda_cli_command_json(conda_executable, "info")
 
@@ -1077,7 +1073,11 @@ def _create_conda_environment(
 ) -> None:  # pragma: no cover
     """Create an empty conda environment."""
     conda_command = [_maybe_exe(conda_executable), "create", "--yes", *args]
-    print(f"📦 Creating empty conda environment with `{' '.join(conda_command)}`\n")
+    print_phase("Creating empty conda environment")
+    print_command(
+        "Creating empty conda environment",
+        " ".join(conda_command),
+    )
     subprocess.run(conda_command, check=True)
 
 
@@ -1164,7 +1164,8 @@ def _pip_install_local(
         else:
             pip_command.append(str(folder))
 
-    print(f"📦 Installing project with `{format_command_for_display(pip_command)}`\n")
+    print_phase("Installing project")
+    print_command("Installing project", format_command_for_display(pip_command))
     if not dry_run:
         _run_with_redacted_command(pip_command)
 
@@ -1224,7 +1225,7 @@ def _conda_dependencies_with_required_pip(
     return dependencies
 
 
-def _install_command(  # noqa: PLR0912
+def _install_command(  # noqa: PLR0912, PLR0915
     *files: Path,
     conda_executable: CondaExecutable | None,
     conda_env_name: str | None,
@@ -1316,7 +1317,11 @@ def _install_command(  # noqa: PLR0912
         # so what we print is what the user would type (copy-paste).
         to_print = [_format_inline_conda_package(pkg) for pkg in conda_dependencies]
         conda_command_str = " ".join((*conda_command, *to_print))
-        print(f"📦 Installing conda dependencies with `{conda_command_str}`\n")
+        print_phase("Installing conda dependencies")
+        print_command(
+            "Installing conda dependencies",
+            conda_command_str,
+        )
         if not dry_run:  # pragma: no cover
             subprocess.run((*conda_command, *conda_dependencies), check=True)
     python_executable = _python_executable(
@@ -1348,9 +1353,10 @@ def _install_command(  # noqa: PLR0912
                 *index_args,
                 *env_spec.pip,
             ]
-        print(
-            f"📦 Installing pip dependencies with "
-            f"`{format_command_for_display(pip_command)}`\n",
+        print_phase("Installing pip dependencies")
+        print_command(
+            "Installing pip dependencies",
+            format_command_for_display(pip_command),
         )
         if not dry_run:  # pragma: no cover
             _run_with_redacted_command(pip_command)
@@ -1499,10 +1505,12 @@ def _create_env_from_lock(  # noqa: PLR0912
     env_identifier = (
         f"'{conda_env_name}'" if conda_env_name else f"at '{conda_env_prefix}'"
     )
-    print(f"📦 Creating conda environment {env_identifier} with `{create_cmd_str}`")
+    label = f"Creating conda environment {env_identifier}"
 
     if not dry_run:  # pragma: no cover
         try:
+            print_phase(label)
+            print_command(label, create_cmd_str, blank_after=False)
             subprocess.run(create_cmd, check=True)
             if verbose:
                 print(f"✅ Environment {env_identifier} created successfully.")
@@ -1510,6 +1518,7 @@ def _create_env_from_lock(  # noqa: PLR0912
             print(f"❌ Failed to create environment: {e}")
             sys.exit(1)
     else:
+        print_command(label, create_cmd_str, blank_after=False)
         print("🏁 Dry run completed. No environment was created.")
 
 
@@ -1795,11 +1804,14 @@ def _print_versions() -> None:  # pragma: no cover
 
 def _print_with_rich(data: list) -> None:
     """Print data as a table using rich, if it's installed."""
-    from rich.console import Console
-    from rich.table import Table
+    console_cls = rich_class("rich.console", "Console")
+    table_cls = rich_class("rich.table", "Table")
+    if console_cls is None or table_cls is None:
+        print("\n".join(data))
+        return
 
-    console = Console()
-    table = Table(show_header=False)
+    console = console_cls()
+    table = table_cls(show_header=False)
     table.add_column("Property", style="cyan")
     table.add_column("Value", style="magenta")
     for line in data:

--- a/unidep/_cli_output.py
+++ b/unidep/_cli_output.py
@@ -1,0 +1,74 @@
+"""CLI output helpers with optional Rich styling."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from typing import Any
+
+
+def rich_class(module_name: str, class_name: str) -> Any | None:
+    """Return a Rich class if Rich is installed."""
+    if importlib.util.find_spec(module_name) is None:
+        return None
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name, None)
+
+
+def _rich_console() -> Any | None:
+    """Return a Rich console for interactive install output, if available."""
+    if not sys.stdout.isatty():
+        return None
+    console_cls = rich_class("rich.console", "Console")
+    if console_cls is None:
+        return None
+
+    return console_cls()
+
+
+def print_command(
+    label: str,
+    command: str,
+    *,
+    emoji: str = "📦",
+    blank_after: bool = True,
+) -> None:
+    """Print an install command, styling the command when Rich is available."""
+    console = _rich_console()
+    if console is None:
+        suffix = "\n" if blank_after else ""
+        print(f"{emoji} {label} with `{command}`{suffix}")
+        return
+
+    text_cls = rich_class("rich.text", "Text")
+    if text_cls is None:
+        suffix = "\n" if blank_after else ""
+        print(f"{emoji} {label} with `{command}`{suffix}")
+        return
+
+    prefix = f"{emoji} {label} with "
+    rendered = text_cls(prefix)
+    rendered.append(command, style="bold cyan")
+    console.print(rendered, soft_wrap=True)
+    if blank_after:
+        console.print()
+
+
+def print_phase(label: str) -> None:
+    """Print a phase line before child installers own terminal output."""
+    console = _rich_console()
+    symbol = "◆"
+    message = f"{symbol} {label}..."
+    if console is None:
+        print(message)
+        return
+
+    text_cls = rich_class("rich.text", "Text")
+    if text_cls is None:
+        console.print(message)
+        return
+    rendered = text_cls()
+    rendered.append(symbol, style="bold green")
+    rendered.append(f" {label}...", style="bold yellow")
+    console.print(rendered, soft_wrap=True)


### PR DESCRIPTION
## Summary
- Add optional Rich rendering for install and install-all command output
- Color exact install command strings while preserving plain fallback output
- Declare direct rich optional dependency and cover plain/Rich command rendering in tests

## Test Plan
- uv run --extra test pytest tests/test_cli.py::test_unidep_install_dry_run tests/test_cli.py::test_unidep_install_all_dry_run tests/test_cli.py::test_install_output_plain_keeps_backtick_command_format tests/test_cli.py::test_install_output_rich_styles_exact_command_text -q --no-cov
- uv run --extra test ruff format --check unidep/_cli.py tests/test_cli.py
- uv run --extra test ruff check unidep/_cli.py tests/test_cli.py

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview unidep end -->