### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/install-example-projects.yml
+++ b/.github/workflows/install-example-projects.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"] # skips 3.7 (unsupported on GH Actions)
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"] # skips 3.7 (unsupported on GH Actions)
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12"] # Just testing the oldest and newest supported versions
+        python-version: ["3.9", "3.12"] # Just testing the oldest and newest supported versions
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]  # skips 3.7 (unsupported on GH Actions)
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:
@@ -28,10 +28,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [[ "${{ matrix.python-version }}" == "3.8" ]]; then
-            # Python 3.8 coverage does not support the "patch" config option
-            sed -i.bak '/patch/d' pyproject.toml && rm pyproject.toml.bak
-          fi
           pip install -e ".[test]"
         shell: bash -el {0}
       - name: Run pytest

--- a/README.md
+++ b/README.md
@@ -1688,9 +1688,9 @@ You might get an error like this when using a `pip` version older than `22.0`:
 ```bash
 $ pip install /path/to/your/project/using/unidep
   ...
-  File "/usr/lib/python3.8/pathlib.py", line 1222, in open
+  File "/usr/lib/python3.9/pathlib.py", line 1222, in open
     return io.open(self, mode, buffering, encoding, errors, newline,
-  File "/usr/lib/python3.8/pathlib.py", line 1078, in _opener
+  File "/usr/lib/python3.9/pathlib.py", line 1078, in _opener
     return self._accessor.open(self, flags, mode)
 FileNotFoundError: [Errno 2] No such file or directory: '/tmp/common-requirements.yaml'
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,9 @@ authors = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
 dependencies = [
     "packaging",
     "ruamel.yaml",
-    "typing_extensions; python_version < '3.8'",
     "tomli; python_version < '3.11'",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.readme]
 file = "README.md"
@@ -28,7 +27,7 @@ conda-lock = ["conda-lock", "conda-package-handling"]
 pip-compile = ["pip-tools"]
 pytest = ["pytest", "GitPython"] # The pytest plugin
 rich = ["rich-argparse"]
-pixi = ["pixi-to-conda-lock; python_version >= '3.9'", "tomli_w"]
+pixi = ["pixi-to-conda-lock", "tomli_w"]
 # Everything except 'test' and 'docs'
 all = [
     "unidep[toml,conda-lock,pip-compile,pytest,rich,pixi]",
@@ -101,7 +100,7 @@ line_length = 88
 
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -131,7 +130,7 @@ ignore = [
 max-complexity = 18
 
 [tool.mypy]
-python_version = "3.8"  # 3.7 is no longer supported by mypy
+python_version = "3.9"
 
 # Use bump-my-version, e.g., call `bump-my-version bump minor`
 [tool.bumpversion]

--- a/tests/test_python_support_policy.py
+++ b/tests/test_python_support_policy.py
@@ -1,0 +1,67 @@
+"""Tests for the supported Python version policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+
+
+def _load_pyproject() -> dict[str, Any]:
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)
+
+
+def _load_workflow(path: str) -> dict[str, Any]:
+    yaml = YAML(typ="safe")
+    with (ROOT / path).open() as f:
+        return yaml.load(f)
+
+
+def test_project_metadata_requires_python_39_or_newer() -> None:
+    pyproject = _load_pyproject()
+
+    assert pyproject["project"]["requires-python"] == ">=3.9"
+    assert pyproject["tool"]["ruff"]["target-version"] == "py39"
+    assert pyproject["tool"]["mypy"]["python_version"] == "3.9"
+    assert not any(
+        dependency.startswith("typing_extensions")
+        for dependency in pyproject["project"]["dependencies"]
+    )
+
+
+def test_ci_matrices_start_at_python_39() -> None:
+    pytest_workflow = _load_workflow(".github/workflows/pytest.yml")
+    install_workflow = _load_workflow(".github/workflows/install-example-projects.yml")
+
+    assert (
+        pytest_workflow["jobs"]["test"]["strategy"]["matrix"]["python-version"]
+        == SUPPORTED_PYTHON_VERSIONS
+    )
+    assert (
+        install_workflow["jobs"]["pip-install"]["strategy"]["matrix"][
+            "python-version"
+        ]
+        == SUPPORTED_PYTHON_VERSIONS
+    )
+    assert (
+        install_workflow["jobs"]["micromamba-install"]["strategy"]["matrix"][
+            "python-version"
+        ]
+        == SUPPORTED_PYTHON_VERSIONS
+    )
+    assert (
+        install_workflow["jobs"]["miniconda-install"]["strategy"]["matrix"][
+            "python-version"
+        ]
+        == ["3.9", "3.12"]
+    )


### PR DESCRIPTION
## Summary
- raise the package Python requirement to 3.9+
- remove Python 3.8 from CI matrices and drop the 3.8 coverage workaround
- add a policy test to keep metadata and CI on the 3.9+ support floor

## Tests
- ============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/unidep-drop-python-38-support.vhhhi5/repo/.venv/bin/python
cachedir: .pytest_cache
rootdir: /private/tmp/unidep-drop-python-38-support.vhhhi5/repo
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, unidep-3.3.4
collecting ... collected 2 items

tests/test_python_support_policy.py::test_project_metadata_requires_python_39_or_newer PASSED [ 50%]
tests/test_python_support_policy.py::test_ci_matrices_start_at_python_39 PASSED [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.14.5-final-0 _______________

Name                                Stmts   Miss  Cover
-------------------------------------------------------
unidep/__init__.py                      5      5     0%
unidep/_cli.py                        404    404     0%
unidep/_conda_env.py                  163    163     0%
unidep/_conda_lock.py                 225    225     0%
unidep/_conflicts.py                  153    153     0%
unidep/_dependencies_parsing.py       447    447     0%
unidep/_dependency_selection.py       362    362     0%
unidep/_doctor.py                     491    491     0%
unidep/_pixi.py                       587    587     0%
unidep/_setuptools_integration.py      77     77     0%
unidep/_version.py                      1      1     0%
unidep/platform_definitions.py         52     52     0%
unidep/utils.py                       254    254     0%
-------------------------------------------------------
TOTAL                                3221   3221     0%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
============================== 2 passed in 0.56s ===============================
- All checks passed!
- 

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--304.org.readthedocs.build/en/304/

<!-- readthedocs-preview unidep end -->