### PR TITLE
Fix uv editable local dependency resolution

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ from unidep._cli import (
     _merge_command,
     _merge_optional_dependency_extras,
     _pip_compile_command,
+    _pip_install_local_arguments,
     _pip_subcommand,
     _print_versions,
     _print_with_rich,
@@ -53,9 +54,6 @@ from unidep._cli import (
 )
 from unidep._dependencies_parsing import parse_requirements
 from unidep._setuptools_integration import _deps
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -401,6 +399,23 @@ def test_install_command_deduplicates_shared_local_dependencies(
     pkgs = " ".join([f"-e {p}" for p in sorted((project1, project2, shared))])
     assert f"pip install --no-deps {pkgs}`" in captured.out
     assert captured.out.count(f"-e {shared}") == 1
+
+
+def test_pip_install_local_arguments_formats_paths() -> None:
+    prefix = ".\\" if os.name == "nt" else "./"
+
+    assert _pip_install_local_arguments(
+        [Path("local_project")],
+        editable=True,
+    ) == ["-e", f"{prefix}local_project"]
+    assert _pip_install_local_arguments(
+        [Path("local_project")],
+        editable=False,
+    ) == [f"{prefix}local_project"]
+    assert _pip_install_local_arguments(
+        [Path("package.whl")],
+        editable=True,
+    ) == [f"{prefix}package.whl"]
 
 
 def _write_editable_install_order_pyproject(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,9 @@ from unittest.mock import patch
 
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 try:
     import tomllib
 except ImportError:  # pragma: no cover
@@ -49,6 +52,7 @@ from unidep._cli import (
     main,
 )
 from unidep._dependencies_parsing import parse_requirements
+from unidep._setuptools_integration import _deps
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -397,6 +401,180 @@ def test_install_command_deduplicates_shared_local_dependencies(
     pkgs = " ".join([f"-e {p}" for p in sorted((project1, project2, shared))])
     assert f"pip install --no-deps {pkgs}`" in captured.out
     assert captured.out.count(f"-e {shared}") == 1
+
+
+def _write_editable_install_order_pyproject(
+    project: Path,
+    *,
+    name: str,
+    unidep_config: str = "",
+) -> None:
+    project.mkdir()
+    package_dir = project / name.replace("-", "_")
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("")
+    if not unidep_config:
+        unidep_config = """
+            [tool.unidep]
+            dependencies = []
+        """
+    (project / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "{name}"
+            version = "0.1.0"
+            {unidep_config}
+            """,
+        ),
+    )
+
+
+@patch("unidep._cli._maybe_conda_executable")
+@patch("unidep._cli._use_uv")
+def test_uv_editable_install_includes_local_deps_in_pip_resolution_phase(
+    mock_use_uv: Any,
+    mock_conda: Any,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_use_uv.return_value = True
+    mock_conda.return_value = None
+    monkeypatch.setenv("PRIVATE_INDEX_TOKEN", "secret-token")
+    app = tmp_path / "app"
+    lib = tmp_path / "lib"
+    _write_editable_install_order_pyproject(lib, name="example-lib")
+    _write_editable_install_order_pyproject(
+        app,
+        name="example-app",
+        unidep_config="""
+            [tool.unidep]
+            dependencies = [
+                { pip = "private-package" },
+            ]
+            pip_indices = [
+                "https://pypi.org/simple/",
+                "https://${PRIVATE_INDEX_TOKEN}@private.example/simple/",
+            ]
+            local_dependencies = [
+                { local = "../lib", pypi = "example-lib" },
+            ]
+        """,
+    )
+
+    _install_command(
+        app,
+        conda_executable=None,
+        conda_env_name=None,
+        conda_env_prefix=None,
+        conda_lock_file=None,
+        dry_run=True,
+        editable=True,
+        skip_conda=True,
+        no_uv=False,
+        verbose=False,
+    )
+
+    output = capsys.readouterr().out
+    commands = re.findall(r"with `([^`]+)`", output)
+    pip_dependency_commands = [
+        cmd for cmd in commands if "uv pip install" in cmd and "private-package" in cmd
+    ]
+    assert len(pip_dependency_commands) == 1
+    pip_dependency_command = pip_dependency_commands[0]
+    assert f"-e {lib}" in pip_dependency_command
+    assert "example-lib" not in pip_dependency_command
+    assert "secret-token" not in output
+
+    final_local_install_commands = [
+        cmd for cmd in commands if "uv pip install" in cmd and f"-e {app}" in cmd
+    ]
+    assert len(final_local_install_commands) == 1
+    final_local_install_command = final_local_install_commands[0]
+    assert "--no-deps" in final_local_install_command
+    assert f"-e {lib}" in final_local_install_command
+
+
+@patch("unidep._cli._maybe_conda_executable")
+@patch("unidep._cli._use_uv")
+def test_uv_editable_install_all_keeps_discovered_local_deps_in_pip_phase(
+    mock_use_uv: Any,
+    mock_conda: Any,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    mock_use_uv.return_value = True
+    mock_conda.return_value = None
+    app = tmp_path / "app"
+    lib = tmp_path / "lib"
+    _write_editable_install_order_pyproject(lib, name="example-lib")
+    _write_editable_install_order_pyproject(
+        app,
+        name="example-app",
+        unidep_config="""
+            [tool.unidep]
+            dependencies = [
+                { pip = "private-package" },
+            ]
+            local_dependencies = [
+                { local = "../lib", pypi = "example-lib" },
+            ]
+        """,
+    )
+
+    _install_command(
+        app,
+        lib,
+        conda_executable=None,
+        conda_env_name=None,
+        conda_env_prefix=None,
+        conda_lock_file=None,
+        dry_run=True,
+        editable=True,
+        skip_conda=True,
+        no_uv=False,
+        verbose=False,
+    )
+
+    output = capsys.readouterr().out
+    commands = re.findall(r"with `([^`]+)`", output)
+    pip_dependency_commands = [
+        cmd for cmd in commands if "uv pip install" in cmd and "private-package" in cmd
+    ]
+    assert len(pip_dependency_commands) == 1
+    assert f"-e {lib}" in pip_dependency_commands[0]
+    assert "example-lib" not in pip_dependency_commands[0]
+
+
+def test_skip_local_deps_env_uses_pypi_fallback_for_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = tmp_path / "app"
+    lib = tmp_path / "lib"
+    _write_editable_install_order_pyproject(lib, name="example-lib")
+    _write_editable_install_order_pyproject(
+        app,
+        name="example-app",
+        unidep_config="""
+            [tool.unidep]
+            local_dependencies = [
+                { local = "../lib", pypi = "example-lib" },
+            ]
+        """,
+    )
+
+    monkeypatch.setenv("UNIDEP_SKIP_LOCAL_DEPS", "1")
+
+    deps = _deps(app / "pyproject.toml")
+
+    assert "example-lib" in deps.dependencies
+    assert not any("file://" in dependency for dependency in deps.dependencies)
 
 
 def mock_uv_env(tmp_path: Path) -> dict[str, str]:

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -19,7 +19,7 @@ import sys
 import time
 from importlib import resources as importlib_resources
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast, get_args
+from typing import TYPE_CHECKING, Literal, NamedTuple, cast, get_args
 
 from ruamel.yaml import YAML
 
@@ -80,6 +80,13 @@ except ImportError:  # pragma: no cover
 
 _DEP_FILES = "`requirements.yaml` or `pyproject.toml`"
 CondaExecutable = Literal["conda", "mamba", "micromamba"]
+
+
+class InstallableLocalPaths(NamedTuple):
+    """Pip-installable local paths split by install phase."""
+
+    all_paths: list[Path]
+    dependency_paths: list[Path]
 
 
 def _flatten_selected_dependency_entries(
@@ -1184,7 +1191,7 @@ def _collect_installable_local_paths(
     paths_with_extras: Sequence[PathWithExtras],
     *,
     verbose: bool,
-) -> tuple[list[Path], list[Path]]:
+) -> InstallableLocalPaths:
     installable: list[Path] = []
     for file in paths_with_extras:
         if is_pip_installable(file.path.parent):
@@ -1217,7 +1224,10 @@ def _collect_installable_local_paths(
             installable_set.add(resolved_dep)
             installable.append(dep)
 
-    return installable, local_dependency_installable
+    return InstallableLocalPaths(
+        all_paths=installable,
+        dependency_paths=local_dependency_installable,
+    )
 
 
 def _conda_dependencies_with_required_pip(
@@ -1298,18 +1308,17 @@ def _install_command(  # noqa: PLR0912, PLR0915
         skip_pip = True
         skip_conda = True
 
-    if not skip_local:
-        installable, local_dependency_installable = _collect_installable_local_paths(
+    if skip_local:
+        local_paths = InstallableLocalPaths(all_paths=[], dependency_paths=[])
+    else:
+        local_paths = _collect_installable_local_paths(
             paths_with_extras,
             verbose=verbose,
         )
-    else:
-        installable = []
-        local_dependency_installable = []
     conda_dependencies = _conda_dependencies_with_required_pip(
         env_spec.conda,
         has_pip_dependencies=bool(env_spec.pip) and not skip_pip,
-        has_local_install_targets=bool(installable),
+        has_local_install_targets=bool(local_paths.all_paths),
         skip_conda=skip_conda,
         conda_executable=conda_executable,
     )
@@ -1352,7 +1361,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
         index_args = build_pip_index_arguments(env_spec.pip_indices)
         use_uv = _use_uv(no_uv)
         local_dependency_args = _pip_install_local_arguments(
-            local_dependency_installable if use_uv and editable else [],
+            local_paths.dependency_paths if use_uv and editable else [],
             editable=True,
         )
         if use_uv:
@@ -1385,7 +1394,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
         if not dry_run:  # pragma: no cover
             _run_with_redacted_command(pip_command)
 
-    if installable:
+    if local_paths.all_paths:
         pip_flags = ["--no-deps"]  # we just ran pip/conda install, so skip
         if verbose:
             pip_flags.append("--verbose")
@@ -1395,7 +1404,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
             conda_env_prefix,
         )
         _pip_install_local(
-            *sorted(installable),
+            *sorted(local_paths.all_paths),
             editable=editable,
             dry_run=dry_run,
             python_executable=python_executable,

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -1116,6 +1116,28 @@ def _run_with_redacted_command(command: Sequence[str | Path]) -> None:
         raise
 
 
+def _pip_install_local_arguments(
+    folders: Sequence[str | Path],
+    *,
+    editable: bool,
+) -> list[str]:
+    args: list[str] = []
+    for folder in sorted(folders):
+        if not os.path.isabs(folder):  # noqa: PTH117
+            relative_prefix = ".\\" if os.name == "nt" else "./"
+            folder = f"{relative_prefix}{folder}"  # noqa: PLW2901
+
+        if (
+            editable
+            and not str(folder).endswith(".whl")
+            and not str(folder).endswith(".zip")
+        ):
+            args.extend(["-e", str(folder)])
+        else:
+            args.append(str(folder))
+    return args
+
+
 def _pip_install_local(
     *folders: str | Path,
     editable: bool,
@@ -1150,19 +1172,7 @@ def _pip_install_local(
     if flags:
         pip_command.extend(flags)
 
-    for folder in sorted(folders):
-        if not os.path.isabs(folder):  # noqa: PTH117
-            relative_prefix = ".\\" if os.name == "nt" else "./"
-            folder = f"{relative_prefix}{folder}"  # noqa: PLW2901
-
-        if (
-            editable
-            and not str(folder).endswith(".whl")
-            and not str(folder).endswith(".zip")
-        ):
-            pip_command.extend(["-e", str(folder)])
-        else:
-            pip_command.append(str(folder))
+    pip_command.extend(_pip_install_local_arguments(folders, editable=editable))
 
     print_phase("Installing project")
     print_command("Installing project", format_command_for_display(pip_command))
@@ -1174,7 +1184,7 @@ def _collect_installable_local_paths(
     paths_with_extras: Sequence[PathWithExtras],
     *,
     verbose: bool,
-) -> list[Path]:
+) -> tuple[list[Path], list[Path]]:
     installable: list[Path] = []
     for file in paths_with_extras:
         if is_pip_installable(file.path.parent):
@@ -1194,15 +1204,20 @@ def _collect_installable_local_paths(
     print(f"📝 Found local dependencies: {names}\n")
 
     installable_set = {p.resolve() for p in installable}
+    local_dependency_installable: list[Path] = []
+    local_dependency_installable_set: set[Path] = set()
     for deps in local_dependencies.values():
         for dep in deps:
             resolved_dep = dep.resolve()
+            if resolved_dep not in local_dependency_installable_set:
+                local_dependency_installable_set.add(resolved_dep)
+                local_dependency_installable.append(dep)
             if resolved_dep in installable_set:
                 continue
             installable_set.add(resolved_dep)
             installable.append(dep)
 
-    return installable
+    return installable, local_dependency_installable
 
 
 def _conda_dependencies_with_required_pip(
@@ -1283,11 +1298,14 @@ def _install_command(  # noqa: PLR0912, PLR0915
         skip_pip = True
         skip_conda = True
 
-    installable = (
-        _collect_installable_local_paths(paths_with_extras, verbose=verbose)
-        if not skip_local
-        else []
-    )
+    if not skip_local:
+        installable, local_dependency_installable = _collect_installable_local_paths(
+            paths_with_extras,
+            verbose=verbose,
+        )
+    else:
+        installable = []
+        local_dependency_installable = []
     conda_dependencies = _conda_dependencies_with_required_pip(
         env_spec.conda,
         has_pip_dependencies=bool(env_spec.pip) and not skip_pip,
@@ -1332,7 +1350,12 @@ def _install_command(  # noqa: PLR0912, PLR0915
     if env_spec.pip and not skip_pip:
         conda_run = _maybe_conda_run(conda_executable, conda_env_name, conda_env_prefix)
         index_args = build_pip_index_arguments(env_spec.pip_indices)
-        if _use_uv(no_uv):
+        use_uv = _use_uv(no_uv)
+        local_dependency_args = _pip_install_local_arguments(
+            local_dependency_installable if use_uv and editable else [],
+            editable=True,
+        )
+        if use_uv:
             pip_command = [
                 *conda_run,
                 "uv",
@@ -1341,6 +1364,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
                 "--python",
                 python_executable,
                 *index_args,
+                *local_dependency_args,
                 *env_spec.pip,
             ]
         else:


### PR DESCRIPTION
## Summary
- Add pip-installable `local_dependencies` as editable direct requirements in the uv pip dependency transaction.
- Keep the final local editable install phase with `--no-deps`.
- Redact credential-bearing pip index URLs in printed install commands.

## Test Plan
- `uv run --extra test ruff check unidep/_cli.py tests/test_cli.py`
- `uv run --extra test pytest tests/test_cli.py::test_uv_editable_install_includes_local_deps_in_pip_resolution_phase tests/test_cli.py::test_uv_editable_install_all_keeps_discovered_local_deps_in_pip_phase tests/test_cli.py::test_skip_local_deps_env_uses_pypi_fallback_for_metadata tests/test_cli.py::test_install_all_command 'tests/test_cli.py::test_unidep_install_all_dry_run[True]' 'tests/test_cli.py::test_unidep_install_all_dry_run[False]' tests/test_cli.py::test_install_command_deduplicates_shared_local_dependencies tests/test_cli.py::test_install_command_installs_pip_when_local_project_needs_pip tests/test_pip_indices_cli.py tests/test_pypi_alternatives.py -q --no-cov`

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--306.org.readthedocs.build/en/306/

<!-- readthedocs-preview unidep end -->