### PR TITLE
Clarify uv editable local dependency handling

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,7 +451,7 @@ def _write_editable_install_order_pyproject(
 
 @patch("unidep._cli._maybe_conda_executable")
 @patch("unidep._cli._use_uv")
-def test_uv_editable_install_includes_local_deps_in_pip_resolution_phase(
+def test_uv_editable_install_passes_local_deps_as_direct_requirements(
     mock_use_uv: Any,
     mock_conda: Any,
     tmp_path: Path,
@@ -497,6 +497,8 @@ def test_uv_editable_install_includes_local_deps_in_pip_resolution_phase(
 
     output = capsys.readouterr().out
     commands = re.findall(r"with `([^`]+)`", output)
+    # Regression: uv can only resolve against requirements in this command.
+    # The local package must be present here, not only in the final no-deps phase.
     pip_dependency_commands = [
         cmd for cmd in commands if "uv pip install" in cmd and "private-package" in cmd
     ]
@@ -517,7 +519,7 @@ def test_uv_editable_install_includes_local_deps_in_pip_resolution_phase(
 
 @patch("unidep._cli._maybe_conda_executable")
 @patch("unidep._cli._use_uv")
-def test_uv_editable_install_all_keeps_discovered_local_deps_in_pip_phase(
+def test_uv_editable_install_all_passes_local_deps_as_direct_requirements(
     mock_use_uv: Any,
     mock_conda: Any,
     tmp_path: Path,

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -1360,6 +1360,9 @@ def _install_command(  # noqa: PLR0912, PLR0915
         conda_run = _maybe_conda_run(conda_executable, conda_env_name, conda_env_prefix)
         index_args = build_pip_index_arguments(env_spec.pip_indices)
         use_uv = _use_uv(no_uv)
+        # uv resolves the whole command up front. Local dependencies must be
+        # direct requirements here; the later --no-deps editable install is too
+        # late to satisfy transitive requirements from private index packages.
         local_dependency_args = _pip_install_local_arguments(
             local_paths.dependency_paths if use_uv and editable else [],
             editable=True,


### PR DESCRIPTION
## Summary
- Add a code comment explaining why uv needs editable local dependencies in the pip dependency transaction.
- Rename the uv editable local dependency tests to state the direct-requirement invariant more clearly.
- Add a regression comment tying the command-shape assertion to uv resolver behavior.

## Test Plan
- `pre-commit run --files unidep/_cli.py tests/test_cli.py`
- `uv run --extra test pytest tests/test_cli.py::test_pip_install_local_arguments_formats_paths tests/test_cli.py::test_uv_editable_install_passes_local_deps_as_direct_requirements tests/test_cli.py::test_uv_editable_install_all_passes_local_deps_as_direct_requirements tests/test_cli.py::test_skip_local_deps_env_uses_pypi_fallback_for_metadata tests/test_cli.py::test_install_all_command 'tests/test_cli.py::test_unidep_install_all_dry_run[True]' 'tests/test_cli.py::test_unidep_install_all_dry_run[False]' tests/test_cli.py::test_install_command_deduplicates_shared_local_dependencies tests/test_cli.py::test_install_command_installs_pip_when_local_project_needs_pip tests/test_pip_indices_cli.py tests/test_pypi_alternatives.py -q --no-cov`


<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--307.org.readthedocs.build/en/307/

<!-- readthedocs-preview unidep end -->