### PR TITLE
Handle missing pip index env vars gracefully

### DIFF
--- a/tests/test_pip_indices_cli.py
+++ b/tests/test_pip_indices_cli.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import os
+import sys
+import textwrap
 from pathlib import Path  # noqa: TC003
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from unidep._cli import main
 from unidep._conda_env import create_conda_env_specification
 from unidep._pip_indices import build_pip_index_arguments
 
@@ -472,6 +475,55 @@ dependencies:
 
 class TestPipIndicesIntegration:
     """Integration tests for pip_indices throughout the workflow."""
+
+    def test_install_all_reports_missing_env_var_without_traceback(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test missing pip_indices env vars produce a clean CLI error."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "requirements.yaml").write_text(
+            textwrap.dedent(
+                """\
+                pip_indices:
+                  - https://${PRIVATE_INDEX_TOKEN}@private.example/simple/
+                dependencies:
+                  - pip: private-package
+                """,
+            ),
+        )
+        monkeypatch.delenv("PRIVATE_INDEX_TOKEN", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "unidep",
+                "install-all",
+                "--directory",
+                str(tmp_path),
+                "--depth",
+                "1",
+                "--dry-run",
+                "--editable",
+                "--skip-conda",
+                "--conda-env-name",
+                "test-env",
+            ],
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        captured = capsys.readouterr()
+        assert excinfo.value.code == 1
+        assert (
+            "Unresolved environment variable(s) PRIVATE_INDEX_TOKEN in pip_indices"
+            in captured.err
+        )
+        assert "Traceback" not in captured.err
 
     def test_full_workflow_with_indices(self, tmp_path: Path) -> None:
         """Test complete workflow from parsing to environment generation."""

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -17,7 +17,6 @@ import shutil
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
 from importlib import resources as importlib_resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple, cast, get_args
@@ -64,7 +63,7 @@ from unidep.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Sequence
 
     from unidep.utils import PathWithExtras
 
@@ -111,15 +110,6 @@ def _collect_available_optional_dependency_groups(
     for found_file in found_files:
         groups.update(_load(found_file, yaml).get("optional_dependencies", {}))
     return sorted(groups)
-
-
-@contextmanager
-def _missing_pip_index_env_vars_as_cli_error() -> Generator[None]:
-    try:
-        yield
-    except MissingPipIndexEnvironmentVariablesError as error:
-        print(f"❌ {error}", file=sys.stderr)
-        sys.exit(1)
 
 
 def _merge_optional_dependency_extras(
@@ -1663,7 +1653,7 @@ def _merge_command(
         env_entries,
         requirements.channels,
         requirements.pip_indices,
-        platforms=platforms,
+        platforms,
         selector=selector,
     )
     output_file = None if stdout else output
@@ -1895,28 +1885,27 @@ def _pip_subcommand(
     return escape_unicode(separator).join(pip_dependencies)
 
 
-def main() -> None:  # noqa: PLR0912
+def _main() -> None:  # noqa: PLR0912
     """Main entry point for the command-line tool."""
     args = _parse_args()
 
     if args.command == "merge":  # pragma: no cover
-        with _missing_pip_index_env_vars_as_cli_error():
-            _merge_command(
-                depth=args.depth,
-                directory=args.directory,
-                files=None,
-                name=args.name,
-                output=args.output,
-                stdout=args.stdout,
-                selector=args.selector,
-                platforms=args.platform,
-                optional_dependencies=args.optional_dependencies,
-                all_optional_dependencies=args.all_optional_dependencies,
-                ignore_pins=args.ignore_pin,
-                skip_dependencies=args.skip_dependency,
-                overwrite_pins=args.overwrite_pin,
-                verbose=args.verbose,
-            )
+        _merge_command(
+            depth=args.depth,
+            directory=args.directory,
+            files=None,
+            name=args.name,
+            output=args.output,
+            stdout=args.stdout,
+            selector=args.selector,
+            platforms=args.platform,
+            optional_dependencies=args.optional_dependencies,
+            all_optional_dependencies=args.all_optional_dependencies,
+            ignore_pins=args.ignore_pin,
+            skip_dependencies=args.skip_dependency,
+            overwrite_pins=args.overwrite_pin,
+            verbose=args.verbose,
+        )
     elif args.command == "pip":  # pragma: no cover
         print(
             _pip_subcommand(
@@ -1943,13 +1932,12 @@ def main() -> None:  # noqa: PLR0912
             requirements.dependency_entries,
             requirements.optional_dependency_entries,
         )
-        with _missing_pip_index_env_vars_as_cli_error():
-            env_spec = create_conda_env_specification(
-                env_entries,
-                requirements.channels,
-                requirements.pip_indices,
-                platforms=platforms,
-            )
+        env_spec = create_conda_env_specification(
+            env_entries,
+            requirements.channels,
+            requirements.pip_indices,
+            platforms=platforms,
+        )
 
         if any(parse_folder_or_filename(f).extras for f in files):
             msg = "🚧 The `conda` command currently does not support extras."
@@ -1960,64 +1948,61 @@ def main() -> None:  # noqa: PLR0912
     elif args.command == "install":
         if args.conda_env_name is None and args.conda_env_prefix is None:
             _check_conda_prefix()
-        with _missing_pip_index_env_vars_as_cli_error():
-            _install_command(
-                *(args.files or [Path()]),
-                conda_executable=args.conda_executable,
-                conda_env_name=args.conda_env_name,
-                conda_env_prefix=args.conda_env_prefix,
-                conda_lock_file=args.conda_lock_file,
-                dry_run=args.dry_run,
-                editable=args.editable,
-                skip_local=args.skip_local,
-                skip_pip=args.skip_pip,
-                skip_conda=args.skip_conda,
-                no_dependencies=args.no_dependencies,
-                ignore_pins=args.ignore_pin,
-                skip_dependencies=args.skip_dependency,
-                overwrite_pins=args.overwrite_pin,
-                no_uv=args.no_uv,
-                verbose=args.verbose,
-            )
+        _install_command(
+            *(args.files or [Path()]),
+            conda_executable=args.conda_executable,
+            conda_env_name=args.conda_env_name,
+            conda_env_prefix=args.conda_env_prefix,
+            conda_lock_file=args.conda_lock_file,
+            dry_run=args.dry_run,
+            editable=args.editable,
+            skip_local=args.skip_local,
+            skip_pip=args.skip_pip,
+            skip_conda=args.skip_conda,
+            no_dependencies=args.no_dependencies,
+            ignore_pins=args.ignore_pin,
+            skip_dependencies=args.skip_dependency,
+            overwrite_pins=args.overwrite_pin,
+            no_uv=args.no_uv,
+            verbose=args.verbose,
+        )
     elif args.command == "install-all":
         if args.conda_env_name is None and args.conda_env_prefix is None:
             _check_conda_prefix()
-        with _missing_pip_index_env_vars_as_cli_error():
-            _install_all_command(
-                conda_executable=args.conda_executable,
-                conda_env_name=args.conda_env_name,
-                conda_env_prefix=args.conda_env_prefix,
-                conda_lock_file=args.conda_lock_file,
-                dry_run=args.dry_run,
-                editable=args.editable,
-                depth=args.depth,
-                directory=args.directory,
-                skip_local=args.skip_local,
-                skip_pip=args.skip_pip,
-                skip_conda=args.skip_conda,
-                no_dependencies=args.no_dependencies,
-                ignore_pins=args.ignore_pin,
-                skip_dependencies=args.skip_dependency,
-                overwrite_pins=args.overwrite_pin,
-                no_uv=args.no_uv,
-                verbose=args.verbose,
-            )
+        _install_all_command(
+            conda_executable=args.conda_executable,
+            conda_env_name=args.conda_env_name,
+            conda_env_prefix=args.conda_env_prefix,
+            conda_lock_file=args.conda_lock_file,
+            dry_run=args.dry_run,
+            editable=args.editable,
+            depth=args.depth,
+            directory=args.directory,
+            skip_local=args.skip_local,
+            skip_pip=args.skip_pip,
+            skip_conda=args.skip_conda,
+            no_dependencies=args.no_dependencies,
+            ignore_pins=args.ignore_pin,
+            skip_dependencies=args.skip_dependency,
+            overwrite_pins=args.overwrite_pin,
+            no_uv=args.no_uv,
+            verbose=args.verbose,
+        )
     elif args.command == "conda-lock":  # pragma: no cover
-        with _missing_pip_index_env_vars_as_cli_error():
-            conda_lock_command(
-                depth=args.depth,
-                directory=args.directory,
-                files=args.file or None,
-                platforms=args.platform,
-                verbose=args.verbose,
-                only_global=args.only_global,
-                ignore_pins=args.ignore_pin,
-                skip_dependencies=args.skip_dependency,
-                overwrite_pins=args.overwrite_pin,
-                check_input_hash=args.check_input_hash,
-                extra_flags=args.extra_flags,
-                lockfile=args.lockfile,
-            )
+        conda_lock_command(
+            depth=args.depth,
+            directory=args.directory,
+            files=args.file or None,
+            platforms=args.platform,
+            verbose=args.verbose,
+            only_global=args.only_global,
+            ignore_pins=args.ignore_pin,
+            skip_dependencies=args.skip_dependency,
+            overwrite_pins=args.overwrite_pin,
+            check_input_hash=args.check_input_hash,
+            extra_flags=args.extra_flags,
+            lockfile=args.lockfile,
+        )
     elif args.command == "pixi":  # pragma: no cover
         _pixi_command(
             depth=args.depth,
@@ -2062,3 +2047,12 @@ def main() -> None:  # noqa: PLR0912
         _print_versions()
     elif args.command == "docs":
         _docs_command()
+
+
+def main() -> None:
+    """Run the command-line tool with user-facing error reporting."""
+    try:
+        _main()
+    except MissingPipIndexEnvironmentVariablesError as error:
+        print(f"❌ {error}", file=sys.stderr)
+        sys.exit(1)

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -38,6 +38,7 @@ from unidep._dependencies_parsing import (
 )
 from unidep._doctor import run_doctor_command
 from unidep._pip_indices import (
+    MissingPipIndexEnvironmentVariablesError,
     build_pip_index_arguments,
     format_command_for_display,
     redact_command_for_exception,
@@ -1884,7 +1885,7 @@ def _pip_subcommand(
     return escape_unicode(separator).join(pip_dependencies)
 
 
-def main() -> None:  # noqa: PLR0912
+def _main() -> None:  # noqa: PLR0912
     """Main entry point for the command-line tool."""
     args = _parse_args()
 
@@ -2046,3 +2047,12 @@ def main() -> None:  # noqa: PLR0912
         _print_versions()
     elif args.command == "docs":
         _docs_command()
+
+
+def main() -> None:
+    """Run the command-line tool with user-facing error reporting."""
+    try:
+        _main()
+    except MissingPipIndexEnvironmentVariablesError as error:
+        print(f"❌ {error}", file=sys.stderr)
+        sys.exit(1)

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from importlib import resources as importlib_resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple, cast, get_args
@@ -63,7 +64,7 @@ from unidep.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Generator, Sequence
 
     from unidep.utils import PathWithExtras
 
@@ -110,6 +111,15 @@ def _collect_available_optional_dependency_groups(
     for found_file in found_files:
         groups.update(_load(found_file, yaml).get("optional_dependencies", {}))
     return sorted(groups)
+
+
+@contextmanager
+def _missing_pip_index_env_vars_as_cli_error() -> Generator[None]:
+    try:
+        yield
+    except MissingPipIndexEnvironmentVariablesError as error:
+        print(f"❌ {error}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _merge_optional_dependency_extras(
@@ -1653,7 +1663,7 @@ def _merge_command(
         env_entries,
         requirements.channels,
         requirements.pip_indices,
-        platforms,
+        platforms=platforms,
         selector=selector,
     )
     output_file = None if stdout else output
@@ -1885,27 +1895,28 @@ def _pip_subcommand(
     return escape_unicode(separator).join(pip_dependencies)
 
 
-def _main() -> None:  # noqa: PLR0912
+def main() -> None:  # noqa: PLR0912
     """Main entry point for the command-line tool."""
     args = _parse_args()
 
     if args.command == "merge":  # pragma: no cover
-        _merge_command(
-            depth=args.depth,
-            directory=args.directory,
-            files=None,
-            name=args.name,
-            output=args.output,
-            stdout=args.stdout,
-            selector=args.selector,
-            platforms=args.platform,
-            optional_dependencies=args.optional_dependencies,
-            all_optional_dependencies=args.all_optional_dependencies,
-            ignore_pins=args.ignore_pin,
-            skip_dependencies=args.skip_dependency,
-            overwrite_pins=args.overwrite_pin,
-            verbose=args.verbose,
-        )
+        with _missing_pip_index_env_vars_as_cli_error():
+            _merge_command(
+                depth=args.depth,
+                directory=args.directory,
+                files=None,
+                name=args.name,
+                output=args.output,
+                stdout=args.stdout,
+                selector=args.selector,
+                platforms=args.platform,
+                optional_dependencies=args.optional_dependencies,
+                all_optional_dependencies=args.all_optional_dependencies,
+                ignore_pins=args.ignore_pin,
+                skip_dependencies=args.skip_dependency,
+                overwrite_pins=args.overwrite_pin,
+                verbose=args.verbose,
+            )
     elif args.command == "pip":  # pragma: no cover
         print(
             _pip_subcommand(
@@ -1932,12 +1943,13 @@ def _main() -> None:  # noqa: PLR0912
             requirements.dependency_entries,
             requirements.optional_dependency_entries,
         )
-        env_spec = create_conda_env_specification(
-            env_entries,
-            requirements.channels,
-            requirements.pip_indices,
-            platforms=platforms,
-        )
+        with _missing_pip_index_env_vars_as_cli_error():
+            env_spec = create_conda_env_specification(
+                env_entries,
+                requirements.channels,
+                requirements.pip_indices,
+                platforms=platforms,
+            )
 
         if any(parse_folder_or_filename(f).extras for f in files):
             msg = "🚧 The `conda` command currently does not support extras."
@@ -1948,61 +1960,64 @@ def _main() -> None:  # noqa: PLR0912
     elif args.command == "install":
         if args.conda_env_name is None and args.conda_env_prefix is None:
             _check_conda_prefix()
-        _install_command(
-            *(args.files or [Path()]),
-            conda_executable=args.conda_executable,
-            conda_env_name=args.conda_env_name,
-            conda_env_prefix=args.conda_env_prefix,
-            conda_lock_file=args.conda_lock_file,
-            dry_run=args.dry_run,
-            editable=args.editable,
-            skip_local=args.skip_local,
-            skip_pip=args.skip_pip,
-            skip_conda=args.skip_conda,
-            no_dependencies=args.no_dependencies,
-            ignore_pins=args.ignore_pin,
-            skip_dependencies=args.skip_dependency,
-            overwrite_pins=args.overwrite_pin,
-            no_uv=args.no_uv,
-            verbose=args.verbose,
-        )
+        with _missing_pip_index_env_vars_as_cli_error():
+            _install_command(
+                *(args.files or [Path()]),
+                conda_executable=args.conda_executable,
+                conda_env_name=args.conda_env_name,
+                conda_env_prefix=args.conda_env_prefix,
+                conda_lock_file=args.conda_lock_file,
+                dry_run=args.dry_run,
+                editable=args.editable,
+                skip_local=args.skip_local,
+                skip_pip=args.skip_pip,
+                skip_conda=args.skip_conda,
+                no_dependencies=args.no_dependencies,
+                ignore_pins=args.ignore_pin,
+                skip_dependencies=args.skip_dependency,
+                overwrite_pins=args.overwrite_pin,
+                no_uv=args.no_uv,
+                verbose=args.verbose,
+            )
     elif args.command == "install-all":
         if args.conda_env_name is None and args.conda_env_prefix is None:
             _check_conda_prefix()
-        _install_all_command(
-            conda_executable=args.conda_executable,
-            conda_env_name=args.conda_env_name,
-            conda_env_prefix=args.conda_env_prefix,
-            conda_lock_file=args.conda_lock_file,
-            dry_run=args.dry_run,
-            editable=args.editable,
-            depth=args.depth,
-            directory=args.directory,
-            skip_local=args.skip_local,
-            skip_pip=args.skip_pip,
-            skip_conda=args.skip_conda,
-            no_dependencies=args.no_dependencies,
-            ignore_pins=args.ignore_pin,
-            skip_dependencies=args.skip_dependency,
-            overwrite_pins=args.overwrite_pin,
-            no_uv=args.no_uv,
-            verbose=args.verbose,
-        )
+        with _missing_pip_index_env_vars_as_cli_error():
+            _install_all_command(
+                conda_executable=args.conda_executable,
+                conda_env_name=args.conda_env_name,
+                conda_env_prefix=args.conda_env_prefix,
+                conda_lock_file=args.conda_lock_file,
+                dry_run=args.dry_run,
+                editable=args.editable,
+                depth=args.depth,
+                directory=args.directory,
+                skip_local=args.skip_local,
+                skip_pip=args.skip_pip,
+                skip_conda=args.skip_conda,
+                no_dependencies=args.no_dependencies,
+                ignore_pins=args.ignore_pin,
+                skip_dependencies=args.skip_dependency,
+                overwrite_pins=args.overwrite_pin,
+                no_uv=args.no_uv,
+                verbose=args.verbose,
+            )
     elif args.command == "conda-lock":  # pragma: no cover
-        conda_lock_command(
-            depth=args.depth,
-            directory=args.directory,
-            files=args.file or None,
-            platforms=args.platform,
-            verbose=args.verbose,
-            only_global=args.only_global,
-            ignore_pins=args.ignore_pin,
-            skip_dependencies=args.skip_dependency,
-            overwrite_pins=args.overwrite_pin,
-            check_input_hash=args.check_input_hash,
-            extra_flags=args.extra_flags,
-            lockfile=args.lockfile,
-        )
+        with _missing_pip_index_env_vars_as_cli_error():
+            conda_lock_command(
+                depth=args.depth,
+                directory=args.directory,
+                files=args.file or None,
+                platforms=args.platform,
+                verbose=args.verbose,
+                only_global=args.only_global,
+                ignore_pins=args.ignore_pin,
+                skip_dependencies=args.skip_dependency,
+                overwrite_pins=args.overwrite_pin,
+                check_input_hash=args.check_input_hash,
+                extra_flags=args.extra_flags,
+                lockfile=args.lockfile,
+            )
     elif args.command == "pixi":  # pragma: no cover
         _pixi_command(
             depth=args.depth,
@@ -2047,12 +2062,3 @@ def _main() -> None:  # noqa: PLR0912
         _print_versions()
     elif args.command == "docs":
         _docs_command()
-
-
-def main() -> None:
-    """Run the command-line tool with user-facing error reporting."""
-    try:
-        _main()
-    except MissingPipIndexEnvironmentVariablesError as error:
-        print(f"❌ {error}", file=sys.stderr)
-        sys.exit(1)

--- a/unidep/_pip_indices.py
+++ b/unidep/_pip_indices.py
@@ -17,6 +17,10 @@ _ENV_VAR_PATTERN = re.compile(
 )
 
 
+class MissingPipIndexEnvironmentVariablesError(ValueError):
+    """Raised when pip index URL environment variable placeholders are unset."""
+
+
 def _validate_pip_indices_env_vars(pip_indices: Sequence[str]) -> tuple[str, ...]:
     """Validate that all env vars referenced by pip index URLs are set."""
     missing_names = sorted(
@@ -33,7 +37,7 @@ def _validate_pip_indices_env_vars(pip_indices: Sequence[str]) -> tuple[str, ...
             f"Unresolved environment variable(s) {names} in pip_indices."
             " Set the variable(s) before running UniDep or remove the placeholder(s)."
         )
-        raise ValueError(msg)
+        raise MissingPipIndexEnvironmentVariablesError(msg)
     return tuple(pip_indices)
 
 


### PR DESCRIPTION
## Summary
- Add a dedicated exception for unresolved `pip_indices` environment variables.
- Catch that exception at the CLI entrypoint and print a concise stderr error instead of a Python traceback.
- Add regression coverage for `install-all` with an unset pip-index token placeholder.

## Test Plan
- `uv run --extra test pytest tests/test_pip_indices_cli.py::TestPipIndicesIntegration::test_install_all_reports_missing_env_var_without_traceback -q --no-cov`
- `uv run ruff check unidep/_cli.py unidep/_pip_indices.py`
- `CONDA_PREFIX=\"$PWD/.venv\" uv run --extra test pytest --cov-fail-under=0`
- Manual temp-project CLI check: missing `PRIVATE_INDEX_TOKEN` exits 1 with one clean stderr line and no traceback

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--308.org.readthedocs.build/en/308/

<!-- readthedocs-preview unidep end -->