### PR TITLE
Add requires_unidep version config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Both files contain the following keys:
 - **optional_dependencies** (Optional): Dictionary with lists of optional dependencies.
 - **platforms** (Optional): List of platforms that are supported (used in `conda-lock`).
 - **pip_indices** (Optional): List of custom pip index URLs for private or alternative package repositories.
-- **minimum_unidep_version** (Optional): Minimum `unidep` version required to parse the file.
+- **requires_unidep** (Optional): Version specifier for the `unidep` version required to parse the file.
 
 Whether you use a `requirements.yaml` or `pyproject.toml` file, the same information can be specified in either.
 Choose the format that works best for your project.
@@ -184,7 +184,7 @@ Example of a `requirements.yaml` file:
 
 ```yaml
 name: example_environment
-minimum_unidep_version: "3.4.1"  # (Optional) require this unidep version or newer
+requires_unidep: ">=3.4.1"  # (Optional) require this unidep version or newer
 channels:
   - conda-forge
 dependencies:
@@ -225,7 +225,7 @@ pip_indices:  # (Optional) additional pip index URLs for private packages
 
 ```toml
 [tool.unidep]
-minimum_unidep_version = "3.4.1"  # (Optional) require this unidep version or newer
+requires_unidep = ">=3.4.1"  # (Optional) require this unidep version or newer
 channels = ["conda-forge"]
 dependencies = [
     "numpy",                                         # same name on conda and pip
@@ -274,7 +274,7 @@ See [Build System Integration](#jigsaw-build-system-integration) for more inform
 - Use `optional_dependencies:` to specify optional dependencies. Can be installed like `unidep install ".[test]"` or `pip install ".[test]"`.
 - Use `platforms:` to specify the platforms that are supported. If omitted, all platforms are assumed to be supported.
 - Use `pip_indices:` to specify additional pip index URLs for installing packages from private or alternative package repositories (see [Custom Pip Index URLs](#custom-pip-index-urls) below).
-- Use `minimum_unidep_version:` to fail early when a file needs a newer `unidep` parser.
+- Use `requires_unidep:` to fail early when a file needs a newer `unidep` parser.
 
 > *We use the YAML notation here, but the same information can be specified in `pyproject.toml` as well.*
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Both files contain the following keys:
 - **optional_dependencies** (Optional): Dictionary with lists of optional dependencies.
 - **platforms** (Optional): List of platforms that are supported (used in `conda-lock`).
 - **pip_indices** (Optional): List of custom pip index URLs for private or alternative package repositories.
+- **minimum_unidep_version** (Optional): Minimum `unidep` version required to parse the file.
 
 Whether you use a `requirements.yaml` or `pyproject.toml` file, the same information can be specified in either.
 Choose the format that works best for your project.
@@ -183,6 +184,7 @@ Example of a `requirements.yaml` file:
 
 ```yaml
 name: example_environment
+minimum_unidep_version: "3.4.1"  # (Optional) require this unidep version or newer
 channels:
   - conda-forge
 dependencies:
@@ -223,6 +225,7 @@ pip_indices:  # (Optional) additional pip index URLs for private packages
 
 ```toml
 [tool.unidep]
+minimum_unidep_version = "3.4.1"  # (Optional) require this unidep version or newer
 channels = ["conda-forge"]
 dependencies = [
     "numpy",                                         # same name on conda and pip
@@ -271,6 +274,7 @@ See [Build System Integration](#jigsaw-build-system-integration) for more inform
 - Use `optional_dependencies:` to specify optional dependencies. Can be installed like `unidep install ".[test]"` or `pip install ".[test]"`.
 - Use `platforms:` to specify the platforms that are supported. If omitted, all platforms are assumed to be supported.
 - Use `pip_indices:` to specify additional pip index URLs for installing packages from private or alternative package repositories (see [Custom Pip Index URLs](#custom-pip-index-urls) below).
+- Use `minimum_unidep_version:` to fail early when a file needs a newer `unidep` parser.
 
 > *We use the YAML notation here, but the same information can be specified in `pyproject.toml` as well.*
 

--- a/tests/test_dependencies_parsing_internal.py
+++ b/tests/test_dependencies_parsing_internal.py
@@ -11,7 +11,6 @@ from unidep._dependencies_parsing import (
     _move_optional_dependencies_to_dependencies,
     parse_requirements,
 )
-from unidep._version import __version__
 from unidep.utils import PathWithExtras
 
 
@@ -61,13 +60,13 @@ def test_is_empty_git_submodule_false_for_non_directory(tmp_path: Path) -> None:
     assert _is_empty_git_submodule(file_path) is False
 
 
-def test_parse_requirements_allows_yaml_with_satisfied_minimum_unidep_version(
+def test_parse_requirements_allows_yaml_with_satisfied_requires_unidep(
     tmp_path: Path,
 ) -> None:
     req_file = tmp_path / "requirements.yaml"
     req_file.write_text(
-        f"""\
-        minimum_unidep_version: "{__version__}"
+        """\
+        requires_unidep: ">=3.4.1"
         dependencies:
           - numpy
         """,
@@ -84,7 +83,7 @@ def test_parse_requirements_allows_yaml_with_satisfied_minimum_unidep_version(
         (
             "requirements.yaml",
             """\
-            minimum_unidep_version: "999.0"
+            requires_unidep: ">=999.0"
             dependencies:
               - numpy
             """,
@@ -93,13 +92,13 @@ def test_parse_requirements_allows_yaml_with_satisfied_minimum_unidep_version(
             "pyproject.toml",
             """\
             [tool.unidep]
-            minimum_unidep_version = "999.0"
+            requires_unidep = ">=999.0"
             dependencies = ["numpy"]
             """,
         ),
     ],
 )
-def test_parse_requirements_rejects_files_requiring_newer_unidep(
+def test_parse_requirements_rejects_unsatisfied_requires_unidep(
     tmp_path: Path,
     filename: str,
     content: str,
@@ -107,17 +106,17 @@ def test_parse_requirements_rejects_files_requiring_newer_unidep(
     req_file = tmp_path / filename
     req_file.write_text(content)
 
-    with pytest.raises(RuntimeError, match=r"requires unidep >= 999\.0"):
+    with pytest.raises(RuntimeError, match=r"requires unidep >=999\.0"):
         parse_requirements(req_file)
 
 
-def test_parse_requirements_rejects_non_string_minimum_unidep_version(
+def test_parse_requirements_rejects_non_string_requires_unidep(
     tmp_path: Path,
 ) -> None:
     req_file = tmp_path / "requirements.yaml"
     req_file.write_text(
         """\
-        minimum_unidep_version: 3.4
+        requires_unidep: 3.4
         dependencies:
           - numpy
         """,
@@ -127,17 +126,33 @@ def test_parse_requirements_rejects_non_string_minimum_unidep_version(
         parse_requirements(req_file)
 
 
-def test_parse_requirements_rejects_invalid_minimum_unidep_version(
+def test_parse_requirements_rejects_invalid_requires_unidep(
     tmp_path: Path,
 ) -> None:
     req_file = tmp_path / "requirements.yaml"
     req_file.write_text(
         """\
-        minimum_unidep_version: "not-a-version"
+        requires_unidep: ">=not-a-version"
         dependencies:
           - numpy
         """,
     )
 
-    with pytest.raises(ValueError, match="Invalid `minimum_unidep_version`"):
+    with pytest.raises(ValueError, match="Invalid `requires_unidep`"):
+        parse_requirements(req_file)
+
+
+def test_parse_requirements_rejects_requires_unidep_without_operator(
+    tmp_path: Path,
+) -> None:
+    req_file = tmp_path / "requirements.yaml"
+    req_file.write_text(
+        """\
+        requires_unidep: "3.4.1"
+        dependencies:
+          - numpy
+        """,
+    )
+
+    with pytest.raises(ValueError, match="must start with a version operator"):
         parse_requirements(req_file)

--- a/tests/test_dependencies_parsing_internal.py
+++ b/tests/test_dependencies_parsing_internal.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 from unidep._dependencies_parsing import (
     _is_empty_git_submodule,
     _move_optional_dependencies_to_dependencies,
     parse_requirements,
 )
+from unidep._version import __version__
 from unidep.utils import PathWithExtras
 
 
@@ -60,3 +59,85 @@ def test_is_empty_git_submodule_false_for_non_directory(tmp_path: Path) -> None:
     file_path = tmp_path / "file.txt"
     file_path.write_text("not a directory")
     assert _is_empty_git_submodule(file_path) is False
+
+
+def test_parse_requirements_allows_yaml_with_satisfied_minimum_unidep_version(
+    tmp_path: Path,
+) -> None:
+    req_file = tmp_path / "requirements.yaml"
+    req_file.write_text(
+        f"""\
+        minimum_unidep_version: "{__version__}"
+        dependencies:
+          - numpy
+        """,
+    )
+
+    requirements = parse_requirements(req_file)
+
+    assert "numpy" in requirements.requirements
+
+
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        (
+            "requirements.yaml",
+            """\
+            minimum_unidep_version: "999.0"
+            dependencies:
+              - numpy
+            """,
+        ),
+        (
+            "pyproject.toml",
+            """\
+            [tool.unidep]
+            minimum_unidep_version = "999.0"
+            dependencies = ["numpy"]
+            """,
+        ),
+    ],
+)
+def test_parse_requirements_rejects_files_requiring_newer_unidep(
+    tmp_path: Path,
+    filename: str,
+    content: str,
+) -> None:
+    req_file = tmp_path / filename
+    req_file.write_text(content)
+
+    with pytest.raises(RuntimeError, match=r"requires unidep >= 999\.0"):
+        parse_requirements(req_file)
+
+
+def test_parse_requirements_rejects_non_string_minimum_unidep_version(
+    tmp_path: Path,
+) -> None:
+    req_file = tmp_path / "requirements.yaml"
+    req_file.write_text(
+        """\
+        minimum_unidep_version: 3.4
+        dependencies:
+          - numpy
+        """,
+    )
+
+    with pytest.raises(TypeError, match="must be a string"):
+        parse_requirements(req_file)
+
+
+def test_parse_requirements_rejects_invalid_minimum_unidep_version(
+    tmp_path: Path,
+) -> None:
+    req_file = tmp_path / "requirements.yaml"
+    req_file.write_text(
+        """\
+        minimum_unidep_version: "not-a-version"
+        dependencies:
+          - numpy
+        """,
+    )
+
+    with pytest.raises(ValueError, match="Invalid `minimum_unidep_version`"):
+        parse_requirements(req_file)

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -13,10 +13,12 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
-from packaging.version import InvalidVersion, Version
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
+from unidep._conflicts import extract_version_operator
 from unidep._version import __version__
 from unidep.platform_definitions import Platform, Spec, platforms_from_selector
 from unidep.utils import (
@@ -191,22 +193,25 @@ def _parse_overwrite_pins(overwrite_pins: list[str]) -> dict[str, str | None]:
     return result
 
 
-def _check_minimum_unidep_version(data: dict[str, Any], path: Path) -> None:
-    minimum = data.get("minimum_unidep_version")
-    if minimum is None:
+def _check_requires_unidep(data: dict[str, Any], path: Path) -> None:
+    requirement = data.get("requires_unidep")
+    if requirement is None:
         return
-    if not isinstance(minimum, str):
-        msg = f"`minimum_unidep_version` in `{path}` must be a string."
+    if not isinstance(requirement, str):
+        msg = f"`requires_unidep` in `{path}` must be a string."
         raise TypeError(msg)
+    if not extract_version_operator(requirement):
+        msg = f"`requires_unidep` in `{path}` must start with a version operator."
+        raise ValueError(msg)
     try:
-        minimum_version = Version(minimum)
-    except InvalidVersion as err:
-        msg = f"Invalid `minimum_unidep_version` in `{path}`: {minimum!r}."
+        specifier = SpecifierSet(requirement)
+    except InvalidSpecifier as err:
+        msg = f"Invalid `requires_unidep` in `{path}`: {requirement!r}."
         raise ValueError(msg) from err
-    if Version(__version__) >= minimum_version:
+    if Version(__version__) in specifier:
         return
     msg = (
-        f"`{path}` requires unidep >= {minimum}, but this is unidep {__version__}. "
+        f"`{path}` requires unidep {requirement}, but this is unidep {__version__}. "
         "Upgrade unidep to use this file."
     )
     raise RuntimeError(msg)
@@ -241,7 +246,7 @@ def _load(p: Path, yaml: YAML) -> dict[str, Any]:
             pyproject = tomllib.load(f)
             project_dependencies = pyproject.get("project", {}).get("dependencies", [])
             unidep_cfg = pyproject["tool"]["unidep"]
-            _check_minimum_unidep_version(unidep_cfg, p)
+            _check_requires_unidep(unidep_cfg, p)
             if not project_dependencies:
                 return unidep_cfg
             unidep_dependencies = unidep_cfg.setdefault("dependencies", [])
@@ -257,7 +262,7 @@ def _load(p: Path, yaml: YAML) -> dict[str, Any]:
             return unidep_cfg
     with p.open() as f:
         data = yaml.load(f)
-        _check_minimum_unidep_version(data, p)
+        _check_requires_unidep(data, p)
         return data
 
 

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -13,9 +13,11 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
+from packaging.version import InvalidVersion, Version
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
+from unidep._version import __version__
 from unidep.platform_definitions import Platform, Spec, platforms_from_selector
 from unidep.utils import (
     LocalDependency,
@@ -189,6 +191,27 @@ def _parse_overwrite_pins(overwrite_pins: list[str]) -> dict[str, str | None]:
     return result
 
 
+def _check_minimum_unidep_version(data: dict[str, Any], path: Path) -> None:
+    minimum = data.get("minimum_unidep_version")
+    if minimum is None:
+        return
+    if not isinstance(minimum, str):
+        msg = f"`minimum_unidep_version` in `{path}` must be a string."
+        raise TypeError(msg)
+    try:
+        minimum_version = Version(minimum)
+    except InvalidVersion as err:
+        msg = f"Invalid `minimum_unidep_version` in `{path}`: {minimum!r}."
+        raise ValueError(msg) from err
+    if Version(__version__) >= minimum_version:
+        return
+    msg = (
+        f"`{path}` requires unidep >= {minimum}, but this is unidep {__version__}. "
+        "Upgrade unidep to use this file."
+    )
+    raise RuntimeError(msg)
+
+
 def _collect_pip_indices(data: dict[str, Any]) -> list[str]:
     """Collect pip index URLs from the unidep config."""
     indices: list[str] = []
@@ -218,6 +241,7 @@ def _load(p: Path, yaml: YAML) -> dict[str, Any]:
             pyproject = tomllib.load(f)
             project_dependencies = pyproject.get("project", {}).get("dependencies", [])
             unidep_cfg = pyproject["tool"]["unidep"]
+            _check_minimum_unidep_version(unidep_cfg, p)
             if not project_dependencies:
                 return unidep_cfg
             unidep_dependencies = unidep_cfg.setdefault("dependencies", [])
@@ -232,7 +256,9 @@ def _load(p: Path, yaml: YAML) -> dict[str, Any]:
             )
             return unidep_cfg
     with p.open() as f:
-        return yaml.load(f)
+        data = yaml.load(f)
+        _check_minimum_unidep_version(data, p)
+        return data
 
 
 def _add_project_dependencies(


### PR DESCRIPTION
## Summary
- add `requires_unidep` support for requirements.yaml and [tool.unidep]
- parse the value as a version specifier such as `>=3.4.1` or `>=3.4.1,<4`
- fail early when the current unidep version does not satisfy the file requirement
- document the new key and cover YAML/TOML parsing behavior

## Tests
- `pytest` (703 passed, 100% coverage)
- `pytest tests/test_dependencies_parsing_internal.py -q --no-cov` (9 passed)
- `ruff check --ignore UP036,PLC0415 unidep/_dependencies_parsing.py tests/test_dependencies_parsing_internal.py`
- `ruff format --check unidep/_dependencies_parsing.py tests/test_dependencies_parsing_internal.py`
- `git diff --check`

Note: full-repo `ruff check .` currently reports existing unrelated lint issues outside this change; changed Python files pass with existing unrelated `UP036`/`PLC0415` ignored.

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--309.org.readthedocs.build/en/309/

<!-- readthedocs-preview unidep end -->