### PR TITLE
Fix skipped pip deps with partial conda locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,8 +934,10 @@ options:
                         packages.
   -f, --conda-lock-file CONDA_LOCK_FILE
                         Path to the `conda-lock.yml` file to use for creating
-                        the new environment. Assumes that the lock file
-                        contains all dependencies. Must be used with `--conda-
+                        the new environment. If UniDep generated the lock with
+                        skipped pip dependencies, those dependencies are
+                        installed from source metadata after the locked
+                        environment is created. Must be used with `--conda-
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.
@@ -1026,8 +1028,10 @@ options:
                         packages.
   -f, --conda-lock-file CONDA_LOCK_FILE
                         Path to the `conda-lock.yml` file to use for creating
-                        the new environment. Assumes that the lock file
-                        contains all dependencies. Must be used with `--conda-
+                        the new environment. If UniDep generated the lock with
+                        skipped pip dependencies, those dependencies are
+                        installed from source metadata after the locked
+                        environment is created. Must be used with `--conda-
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,9 +56,9 @@ from unidep._conda_env import CondaEnvironmentSpec
 from unidep._conda_lock import (
     _canonical_dependency_name,
     _conda_dependency_name,
-    _filter_env_spec_to_lock_skipped_pip_dependencies,
-    _parse_lock_skipped_dependencies,
     _pip_requirement_name,
+    filter_env_spec_to_lock_skipped_pip_dependencies,
+    parse_lock_skipped_dependencies,
 )
 from unidep._dependencies_parsing import parse_requirements
 from unidep._setuptools_integration import _deps
@@ -2272,7 +2272,7 @@ def test_parse_lock_skipped_dependencies_from_command_header(tmp_path: Path) -> 
         ),
     )
 
-    assert _parse_lock_skipped_dependencies(lock_file) == [
+    assert parse_lock_skipped_dependencies(lock_file) == [
         "acme.private-runtime",
         "acme.private-config",
     ]
@@ -2283,10 +2283,10 @@ def test_parse_lock_skipped_dependencies_handles_missing_and_malformed_lock(
 ) -> None:
     lock_file = tmp_path / "conda-lock.yml"
 
-    assert _parse_lock_skipped_dependencies(lock_file) == []
+    assert parse_lock_skipped_dependencies(lock_file) == []
 
     lock_file.write_text("version: 1\nmetadata: {}\npackage: []\n")
-    assert _parse_lock_skipped_dependencies(lock_file) == []
+    assert parse_lock_skipped_dependencies(lock_file) == []
 
     lock_file.write_text(
         textwrap.dedent(
@@ -2302,7 +2302,7 @@ def test_parse_lock_skipped_dependencies_handles_missing_and_malformed_lock(
             """,
         ),
     )
-    assert _parse_lock_skipped_dependencies(lock_file) == []
+    assert parse_lock_skipped_dependencies(lock_file) == []
 
 
 @pytest.mark.parametrize(
@@ -2321,7 +2321,7 @@ def test_parse_lock_skipped_dependencies_ignores_invalid_metadata_shapes(
     lock_file = tmp_path / "conda-lock.yml"
     lock_file.write_text(lock_text)
 
-    assert _parse_lock_skipped_dependencies(lock_file) == []
+    assert parse_lock_skipped_dependencies(lock_file) == []
 
 
 def test_lock_skipped_dependency_name_helpers() -> None:
@@ -2348,7 +2348,7 @@ def test_partial_lock_install_errors_for_skipped_conda_dependencies(
     )
 
     with pytest.raises(SystemExit):
-        _filter_env_spec_to_lock_skipped_pip_dependencies(env_spec, ["numpy"])
+        filter_env_spec_to_lock_skipped_pip_dependencies(env_spec, ["numpy"])
 
     output = capsys.readouterr().out
     assert "can only repair skipped pip dependencies" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,17 +27,14 @@ except ImportError:  # pragma: no cover
 import unidep._cli as cli
 from unidep._cli import (
     CondaExecutable,
-    _canonical_dependency_name,
     _capitalize_dir,
     _check_conda_prefix,
     _collect_available_optional_dependency_groups,
     _collect_selected_conda_like_platforms,
     _conda_dependencies_with_required_pip,
-    _conda_dependency_name,
     _conda_env_list,
     _conda_info,
     _conda_root_prefix,
-    _filter_env_spec_to_lock_skipped_pip_dependencies,
     _find_windows_path,
     _flatten_selected_dependency_entries,
     _get_conda_executable,
@@ -48,16 +45,21 @@ from unidep._cli import (
     _maybe_create_conda_env_args,
     _merge_command,
     _merge_optional_dependency_extras,
-    _parse_lock_skipped_dependencies,
     _pip_compile_command,
     _pip_install_local_arguments,
-    _pip_requirement_name,
     _pip_subcommand,
     _print_versions,
     _print_with_rich,
     main,
 )
 from unidep._conda_env import CondaEnvironmentSpec
+from unidep._conda_lock import (
+    _canonical_dependency_name,
+    _conda_dependency_name,
+    _filter_env_spec_to_lock_skipped_pip_dependencies,
+    _parse_lock_skipped_dependencies,
+    _pip_requirement_name,
+)
 from unidep._dependencies_parsing import parse_requirements
 from unidep._setuptools_integration import _deps
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,14 +27,17 @@ except ImportError:  # pragma: no cover
 import unidep._cli as cli
 from unidep._cli import (
     CondaExecutable,
+    _canonical_dependency_name,
     _capitalize_dir,
     _check_conda_prefix,
     _collect_available_optional_dependency_groups,
     _collect_selected_conda_like_platforms,
     _conda_dependencies_with_required_pip,
+    _conda_dependency_name,
     _conda_env_list,
     _conda_info,
     _conda_root_prefix,
+    _filter_env_spec_to_lock_skipped_pip_dependencies,
     _find_windows_path,
     _flatten_selected_dependency_entries,
     _get_conda_executable,
@@ -45,13 +48,16 @@ from unidep._cli import (
     _maybe_create_conda_env_args,
     _merge_command,
     _merge_optional_dependency_extras,
+    _parse_lock_skipped_dependencies,
     _pip_compile_command,
     _pip_install_local_arguments,
+    _pip_requirement_name,
     _pip_subcommand,
     _print_versions,
     _print_with_rich,
     main,
 )
+from unidep._conda_env import CondaEnvironmentSpec
 from unidep._dependencies_parsing import parse_requirements
 from unidep._setuptools_integration import _deps
 
@@ -2151,6 +2157,200 @@ def test_install_command_with_conda_lock_skips_dependency_install(
     output = capsys.readouterr().out
     assert "Installing conda dependencies" not in output
     assert "Installing pip dependencies" not in output
+
+
+@patch("unidep._cli._use_uv")
+def test_install_command_with_partial_conda_lock_installs_skipped_pip_deps(
+    mock_use_uv: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    mock_use_uv.return_value = True
+    monkeypatch.setenv("PRIVATE_INDEX_TOKEN", "secret-token")
+    app = tmp_path / "app"
+    lib = tmp_path / "lib"
+    _write_editable_install_order_pyproject(lib, name="pkg-a")
+    _write_editable_install_order_pyproject(
+        app,
+        name="pkg-b",
+        unidep_config="""
+            [tool.unidep]
+            dependencies = [
+                { pip = "acme.private-runtime" },
+                { pip = "public-helper" },
+            ]
+            pip_indices = [
+                "https://${PRIVATE_INDEX_TOKEN}@private.example/simple/",
+                "https://pypi.org/simple/",
+            ]
+            local_dependencies = [
+                { local = "../lib", pypi = "pkg-a" },
+            ]
+        """,
+    )
+    lock_file = tmp_path / "conda-lock.yml"
+    lock_file.write_text(
+        textwrap.dedent(
+            """\
+            version: 1
+            metadata:
+              channels:
+                - url: conda-forge
+              platforms:
+                - linux-64
+              unidep:
+                skipped_dependencies:
+                  - acme.private-runtime
+            package: []
+            """,
+        ),
+    )
+    created: list[Path] = []
+
+    def fake_create_env_from_lock(
+        conda_lock_file: Path,
+        _conda_executable: str,
+        **_: object,
+    ) -> None:
+        created.append(conda_lock_file)
+
+    monkeypatch.setattr("unidep._cli._create_env_from_lock", fake_create_env_from_lock)
+    monkeypatch.setattr("unidep._cli.identify_current_platform", lambda: "linux-64")
+    monkeypatch.setattr("unidep._cli._python_executable", lambda *_: "python")
+
+    _install_command(
+        app,
+        lib,
+        conda_executable="micromamba",
+        conda_env_name="test-env",
+        conda_env_prefix=None,
+        conda_lock_file=lock_file,
+        dry_run=True,
+        editable=True,
+        no_uv=False,
+        verbose=False,
+    )
+
+    output = capsys.readouterr().out
+    commands = re.findall(r"with `([^`]+)`", output)
+    pip_dependency_commands = [
+        cmd
+        for cmd in commands
+        if "uv pip install" in cmd and "acme.private-runtime" in cmd
+    ]
+    assert created == [lock_file]
+    assert len(pip_dependency_commands) == 1
+    pip_dependency_command = pip_dependency_commands[0]
+    assert f"-e {lib}" in pip_dependency_command
+    assert "public-helper" not in pip_dependency_command
+    assert "secret-token" not in output
+    assert "Installing conda dependencies" not in output
+
+
+def test_parse_lock_skipped_dependencies_from_command_header(tmp_path: Path) -> None:
+    lock_file = tmp_path / "conda-lock.yml"
+    generated_header = (
+        "# This file is created and managed by `unidep` 3.4.1.\n"
+        "# File generated with: `unidep conda-lock -d . "
+        "--skip-dependency acme.private-runtime "
+        "--skip-dependency=acme.private-config`\n\n"
+    )
+    lock_file.write_text(
+        generated_header
+        + textwrap.dedent(
+            """\
+            version: 1
+            metadata:
+              channels: []
+              platforms:
+                - linux-64
+            package: []
+            """,
+        ),
+    )
+
+    assert _parse_lock_skipped_dependencies(lock_file) == [
+        "acme.private-runtime",
+        "acme.private-config",
+    ]
+
+
+def test_parse_lock_skipped_dependencies_handles_missing_and_malformed_lock(
+    tmp_path: Path,
+) -> None:
+    lock_file = tmp_path / "conda-lock.yml"
+
+    assert _parse_lock_skipped_dependencies(lock_file) == []
+
+    lock_file.write_text("version: 1\nmetadata: {}\npackage: []\n")
+    assert _parse_lock_skipped_dependencies(lock_file) == []
+
+    lock_file.write_text(
+        textwrap.dedent(
+            """\
+            # ordinary comment
+            # File generated with: unidep conda-lock
+            # File generated with: `unidep conda-lock --skip-dependency 'open`
+            # File generated with: `unidep conda-lock`
+
+            version: 1
+            metadata: {}
+            package: []
+            """,
+        ),
+    )
+    assert _parse_lock_skipped_dependencies(lock_file) == []
+
+
+@pytest.mark.parametrize(
+    "lock_text",
+    [
+        "[]\n",
+        "version: 1\nmetadata: []\npackage: []\n",
+        "version: 1\nmetadata:\n  unidep: []\npackage: []\n",
+        "version: 1\nmetadata:\n  unidep:\n    skipped_dependencies: private\npackage: []\n",
+    ],
+)
+def test_parse_lock_skipped_dependencies_ignores_invalid_metadata_shapes(
+    tmp_path: Path,
+    lock_text: str,
+) -> None:
+    lock_file = tmp_path / "conda-lock.yml"
+    lock_file.write_text(lock_text)
+
+    assert _parse_lock_skipped_dependencies(lock_file) == []
+
+
+def test_lock_skipped_dependency_name_helpers() -> None:
+    assert _canonical_dependency_name("Acme.Private[extra]") == "acme-private"
+    assert (
+        _pip_requirement_name(
+            "Acme.Private[extra] >=1; python_version >= '3.11'",
+        )
+        == "acme-private"
+    )
+    assert _pip_requirement_name("Acme.Private >=1:linux64") == "acme-private"
+    assert _conda_dependency_name({"sel(linux)": "ZLib >=1"}) == "zlib"
+
+
+def test_partial_lock_install_errors_for_skipped_conda_dependencies(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    env_spec = CondaEnvironmentSpec(
+        channels=[],
+        platforms=["linux-64"],
+        conda=["numpy >=1"],
+        pip=[],
+        pip_indices=(),
+    )
+
+    with pytest.raises(SystemExit):
+        _filter_env_spec_to_lock_skipped_pip_dependencies(env_spec, ["numpy"])
+
+    output = capsys.readouterr().out
+    assert "can only repair skipped pip dependencies" in output
+    assert "numpy >=1" in output
 
 
 def test_unidep_merge_cli_optional_dependencies(tmp_path: Path) -> None:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -18,6 +18,7 @@ from unidep._conda_lock import (
     _conda_lock_subpackage,
     _conda_lock_subpackages,
     _download_and_get_package_names,
+    _ensure_pip_runtime_for_skipped_dependencies,
     _handle_missing_keys,
     _parse_conda_lock_packages,
     conda_lock_command,
@@ -321,6 +322,76 @@ dependencies = []
     assert "Missing keys" not in out
     assert "private-config" not in out
     assert "private-runtime" not in out
+    with YAML(typ="safe") as yaml:
+        with (tmp_path / "conda-lock.yml").open() as fp:
+            global_lock = yaml.load(fp)
+        with (app / "conda-lock.yml").open() as fp:
+            app_lock = yaml.load(fp)
+    expected_skipped = ["private-config", "private-runtime"]
+    assert global_lock["metadata"]["unidep"]["skipped_dependencies"] == expected_skipped
+    assert app_lock["metadata"]["unidep"]["skipped_dependencies"] == expected_skipped
+
+
+def test_conda_lock_with_only_skipped_pip_deps_keeps_pip_runtime(
+    tmp_path: Path,
+) -> None:
+    req_file = _write_private_index_project(
+        tmp_path,
+        """\
+    { pip = "private-runtime" },
+""",
+        auth_value="fixed",
+    )
+
+    def fake_run_conda_lock(
+        tmp_env: Path,
+        conda_lock_output: Path,
+        *,
+        check_input_hash: bool,
+        extra_flags: list[str],
+    ) -> None:
+        del check_input_hash, extra_flags
+        with YAML(typ="safe") as yaml, tmp_env.open() as fp:
+            env = yaml.load(fp)
+        assert "pip" in env["dependencies"]
+        _write_fake_lock_file(conda_lock_output, [])
+
+    with patch("unidep._conda_lock._run_conda_lock", side_effect=fake_run_conda_lock):
+        conda_lock_command(
+            depth=1,
+            directory=tmp_path,
+            files=[req_file],
+            platforms=["linux-64"],
+            verbose=False,
+            only_global=True,
+            check_input_hash=False,
+            ignore_pins=[],
+            overwrite_pins=[],
+            skip_dependencies=["private-runtime"],
+            extra_flags=[],
+        )
+
+
+def test_ensure_pip_runtime_for_skipped_dependencies_does_not_duplicate_pip(
+    tmp_path: Path,
+) -> None:
+    tmp_env = tmp_path / "environment.yaml"
+    tmp_env.write_text(
+        """\
+name: test
+dependencies:
+  - pip >=24
+  - pip:
+      - public-helper
+""",
+    )
+
+    _ensure_pip_runtime_for_skipped_dependencies(tmp_env, ["private-runtime"])
+
+    with YAML(typ="safe") as yaml, tmp_env.open() as fp:
+        env = yaml.load(fp)
+    assert env["dependencies"].count("pip >=24") == 1
+    assert "pip" not in env["dependencies"]
 
 
 def test_conda_lock_fails_before_lock_when_pip_index_env_var_is_unset(

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -13,8 +13,6 @@ import itertools
 import json
 import os
 import platform
-import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -23,8 +21,6 @@ from importlib import resources as importlib_resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple, cast, get_args
 
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.utils import canonicalize_name
 from ruamel.yaml import YAML
 
 from unidep._cli_output import print_command, print_phase, rich_class
@@ -33,7 +29,11 @@ from unidep._conda_env import (
     create_conda_env_specification,
     write_conda_environment_file,
 )
-from unidep._conda_lock import conda_lock_command
+from unidep._conda_lock import (
+    _filter_env_spec_to_lock_skipped_pip_dependencies,
+    _parse_lock_skipped_dependencies,
+    conda_lock_command,
+)
 from unidep._dependencies_parsing import (
     DependencyEntry,
     _load,
@@ -1130,118 +1130,6 @@ def _run_with_redacted_command(command: Sequence[str | Path]) -> None:
         exc.cmd = redact_command_for_exception(exc.cmd)
         raise
 
-
-def _strip_pip_extras(name: str) -> str:
-    if not name.endswith("]") or "[" not in name:
-        return name
-    return name.split("[", 1)[0]
-
-
-def _canonical_dependency_name(name: str) -> str:
-    return canonicalize_name(_strip_pip_extras(name))
-
-
-def _pip_requirement_name(requirement: str) -> str:
-    try:
-        return _canonical_dependency_name(Requirement(requirement).name)
-    except InvalidRequirement:
-        dependency = requirement.split(";", 1)[0].strip()
-        return _canonical_dependency_name(parse_package_str(dependency).name)
-
-
-def _conda_dependency_name(dependency: str | dict[str, str]) -> str:
-    dependency_str = (
-        next(iter(dependency.values())) if isinstance(dependency, dict) else dependency
-    )
-    return _canonical_dependency_name(parse_package_str(dependency_str).name)
-
-
-def _parse_lock_header_skipped_dependencies(conda_lock_file: Path) -> list[str]:
-    if not conda_lock_file.exists():
-        return []
-    for line in conda_lock_file.read_text().splitlines():
-        if "File generated with:" not in line:
-            continue
-        match = re.search(r"`unidep (?P<args>.*)`", line)
-        if match is None:
-            continue
-        try:
-            tokens = shlex.split(match.group("args"))
-        except ValueError:
-            continue
-        skipped: list[str] = []
-        i = 0
-        while i < len(tokens):
-            argument = tokens[i]
-            if argument == "--skip-dependency" and i + 1 < len(tokens):
-                skipped.append(tokens[i + 1])
-                i += 2
-                continue
-            if argument.startswith("--skip-dependency="):
-                skipped.append(argument.split("=", 1)[1])
-            i += 1
-        return skipped
-    return []
-
-
-def _parse_lock_metadata_skipped_dependencies(conda_lock_file: Path) -> list[str]:
-    if not conda_lock_file.exists():
-        return []
-    yaml = YAML(typ="safe")
-    with conda_lock_file.open() as fp:
-        data = yaml.load(fp)
-    if not isinstance(data, dict):
-        return []
-    metadata = data.get("metadata", {})
-    if not isinstance(metadata, dict):
-        return []
-    unidep_metadata = metadata.get("unidep", {})
-    if not isinstance(unidep_metadata, dict):
-        return []
-    skipped = unidep_metadata.get("skipped_dependencies", [])
-    if not isinstance(skipped, list):
-        return []
-    return [str(dependency) for dependency in skipped]
-
-
-def _parse_lock_skipped_dependencies(conda_lock_file: Path) -> list[str]:
-    skipped = _parse_lock_metadata_skipped_dependencies(conda_lock_file)
-    if skipped:
-        return skipped
-    return _parse_lock_header_skipped_dependencies(conda_lock_file)
-
-
-def _filter_env_spec_to_lock_skipped_pip_dependencies(
-    env_spec: CondaEnvironmentSpec,
-    skipped_dependencies: list[str],
-) -> CondaEnvironmentSpec:
-    skipped_names = {
-        _canonical_dependency_name(dependency) for dependency in skipped_dependencies
-    }
-    pip_dependencies = [
-        dependency
-        for dependency in env_spec.pip
-        if _pip_requirement_name(dependency) in skipped_names
-    ]
-    conda_dependencies = [
-        dependency
-        for dependency in env_spec.conda
-        if _conda_dependency_name(dependency) in skipped_names
-    ]
-    if conda_dependencies:
-        dependencies = ", ".join(
-            sorted(str(dependency) for dependency in conda_dependencies),
-        )
-        print(
-            "❌ `conda-lock.yml` was generated with skipped dependencies that"
-            f" resolve to conda packages on this platform: {dependencies}."
-            " `install-all -f` can only repair skipped pip dependencies after"
-            " creating the locked environment. Regenerate the lock without"
-            " skipping those conda dependencies, or run the metadata install"
-            " path without `-f`.",
-        )
-        sys.exit(1)
-    return env_spec._replace(conda=[], pip=pip_dependencies)
 
 
 def _pip_install_local_arguments(

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -30,9 +30,9 @@ from unidep._conda_env import (
     write_conda_environment_file,
 )
 from unidep._conda_lock import (
-    _filter_env_spec_to_lock_skipped_pip_dependencies,
-    _parse_lock_skipped_dependencies,
     conda_lock_command,
+    filter_env_spec_to_lock_skipped_pip_dependencies,
+    parse_lock_skipped_dependencies,
 )
 from unidep._dependencies_parsing import (
     DependencyEntry,
@@ -1312,9 +1312,9 @@ def _install_command(  # noqa: PLR0912, PLR0915
             verbose=verbose,
         )
         if not no_dependencies:
-            skipped_dependencies = _parse_lock_skipped_dependencies(conda_lock_file)
+            skipped_dependencies = parse_lock_skipped_dependencies(conda_lock_file)
             if skipped_dependencies:
-                env_spec = _filter_env_spec_to_lock_skipped_pip_dependencies(
+                env_spec = filter_env_spec_to_lock_skipped_pip_dependencies(
                     env_spec,
                     skipped_dependencies,
                 )

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -13,6 +13,8 @@ import itertools
 import json
 import os
 import platform
+import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -21,10 +23,13 @@ from importlib import resources as importlib_resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple, cast, get_args
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from ruamel.yaml import YAML
 
 from unidep._cli_output import print_command, print_phase, rich_class
 from unidep._conda_env import (
+    CondaEnvironmentSpec,
     create_conda_env_specification,
     write_conda_environment_file,
 )
@@ -343,7 +348,9 @@ def _add_common_args(  # noqa: PLR0912, C901
             "--conda-lock-file",
             type=Path,
             help="Path to the `conda-lock.yml` file to use for creating the new"
-            " environment. Assumes that the lock file contains all dependencies."
+            " environment. If UniDep generated the lock with skipped pip"
+            " dependencies, those dependencies are installed from source metadata"
+            " after the locked environment is created."
             " Must be used with `--conda-env-name` or `--conda-env-prefix`.",
         )
     if "no-uv" in options:
@@ -1124,6 +1131,119 @@ def _run_with_redacted_command(command: Sequence[str | Path]) -> None:
         raise
 
 
+def _strip_pip_extras(name: str) -> str:
+    if not name.endswith("]") or "[" not in name:
+        return name
+    return name.split("[", 1)[0]
+
+
+def _canonical_dependency_name(name: str) -> str:
+    return canonicalize_name(_strip_pip_extras(name))
+
+
+def _pip_requirement_name(requirement: str) -> str:
+    try:
+        return _canonical_dependency_name(Requirement(requirement).name)
+    except InvalidRequirement:
+        dependency = requirement.split(";", 1)[0].strip()
+        return _canonical_dependency_name(parse_package_str(dependency).name)
+
+
+def _conda_dependency_name(dependency: str | dict[str, str]) -> str:
+    dependency_str = (
+        next(iter(dependency.values())) if isinstance(dependency, dict) else dependency
+    )
+    return _canonical_dependency_name(parse_package_str(dependency_str).name)
+
+
+def _parse_lock_header_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    if not conda_lock_file.exists():
+        return []
+    for line in conda_lock_file.read_text().splitlines():
+        if "File generated with:" not in line:
+            continue
+        match = re.search(r"`unidep (?P<args>.*)`", line)
+        if match is None:
+            continue
+        try:
+            tokens = shlex.split(match.group("args"))
+        except ValueError:
+            continue
+        skipped: list[str] = []
+        i = 0
+        while i < len(tokens):
+            argument = tokens[i]
+            if argument == "--skip-dependency" and i + 1 < len(tokens):
+                skipped.append(tokens[i + 1])
+                i += 2
+                continue
+            if argument.startswith("--skip-dependency="):
+                skipped.append(argument.split("=", 1)[1])
+            i += 1
+        return skipped
+    return []
+
+
+def _parse_lock_metadata_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    if not conda_lock_file.exists():
+        return []
+    yaml = YAML(typ="safe")
+    with conda_lock_file.open() as fp:
+        data = yaml.load(fp)
+    if not isinstance(data, dict):
+        return []
+    metadata = data.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return []
+    unidep_metadata = metadata.get("unidep", {})
+    if not isinstance(unidep_metadata, dict):
+        return []
+    skipped = unidep_metadata.get("skipped_dependencies", [])
+    if not isinstance(skipped, list):
+        return []
+    return [str(dependency) for dependency in skipped]
+
+
+def _parse_lock_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    skipped = _parse_lock_metadata_skipped_dependencies(conda_lock_file)
+    if skipped:
+        return skipped
+    return _parse_lock_header_skipped_dependencies(conda_lock_file)
+
+
+def _filter_env_spec_to_lock_skipped_pip_dependencies(
+    env_spec: CondaEnvironmentSpec,
+    skipped_dependencies: list[str],
+) -> CondaEnvironmentSpec:
+    skipped_names = {
+        _canonical_dependency_name(dependency) for dependency in skipped_dependencies
+    }
+    pip_dependencies = [
+        dependency
+        for dependency in env_spec.pip
+        if _pip_requirement_name(dependency) in skipped_names
+    ]
+    conda_dependencies = [
+        dependency
+        for dependency in env_spec.conda
+        if _conda_dependency_name(dependency) in skipped_names
+    ]
+    if conda_dependencies:
+        dependencies = ", ".join(
+            sorted(str(dependency) for dependency in conda_dependencies),
+        )
+        print(
+            "❌ `conda-lock.yml` was generated with skipped dependencies that"
+            f" resolve to conda packages on this platform: {dependencies}."
+            " `install-all -f` can only repair skipped pip dependencies after"
+            " creating the locked environment. Regenerate the lock without"
+            " skipping those conda dependencies, or run the metadata install"
+            " path without `-f`.",
+        )
+        sys.exit(1)
+    return env_spec._replace(conda=[], pip=pip_dependencies)
+
+
 def _pip_install_local_arguments(
     folders: Sequence[str | Path],
     *,
@@ -1303,7 +1423,16 @@ def _install_command(  # noqa: PLR0912, PLR0915
             dry_run=dry_run,
             verbose=verbose,
         )
-        no_dependencies = True  # Assume the lock file has all dependencies
+        if not no_dependencies:
+            skipped_dependencies = _parse_lock_skipped_dependencies(conda_lock_file)
+            if skipped_dependencies:
+                env_spec = _filter_env_spec_to_lock_skipped_pip_dependencies(
+                    env_spec,
+                    skipped_dependencies,
+                )
+                skip_conda = True
+            else:
+                no_dependencies = True  # Assume the lock file has all dependencies
 
     if no_dependencies:
         skip_pip = True

--- a/unidep/_conda_lock.py
+++ b/unidep/_conda_lock.py
@@ -5,6 +5,8 @@ This module provides the `unidep conda-lock` CLI command, used in `unidep._cli`.
 
 from __future__ import annotations
 
+import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -15,6 +17,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from ruamel.yaml import YAML
 
@@ -33,6 +36,7 @@ from unidep.utils import (
 if TYPE_CHECKING:
     from typing import Literal
 
+    from unidep._conda_env import CondaEnvironmentSpec
     from unidep.platform_definitions import CondaPip, Platform
 
 
@@ -278,6 +282,113 @@ def _strip_pip_extras(name: str) -> str:
     if not name.endswith("]") or "[" not in name:
         return name
     return name.split("[", 1)[0]
+
+
+def _canonical_dependency_name(name: str) -> str:
+    return canonicalize_name(_strip_pip_extras(name))
+
+
+def _pip_requirement_name(requirement: str) -> str:
+    try:
+        return _canonical_dependency_name(Requirement(requirement).name)
+    except InvalidRequirement:
+        dependency = requirement.split(";", 1)[0].strip()
+        return _canonical_dependency_name(parse_package_str(dependency).name)
+
+
+def _conda_dependency_name(dependency: str | dict[str, str]) -> str:
+    dependency_str = (
+        next(iter(dependency.values())) if isinstance(dependency, dict) else dependency
+    )
+    return _canonical_dependency_name(parse_package_str(dependency_str).name)
+
+
+def _parse_lock_header_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    if not conda_lock_file.exists():
+        return []
+    for line in conda_lock_file.read_text().splitlines():
+        if "File generated with:" not in line:
+            continue
+        match = re.search(r"`unidep (?P<args>.*)`", line)
+        if match is None:
+            continue
+        try:
+            tokens = shlex.split(match.group("args"))
+        except ValueError:
+            continue
+        skipped: list[str] = []
+        i = 0
+        while i < len(tokens):
+            argument = tokens[i]
+            if argument == "--skip-dependency" and i + 1 < len(tokens):
+                skipped.append(tokens[i + 1])
+                i += 2
+                continue
+            if argument.startswith("--skip-dependency="):
+                skipped.append(argument.split("=", 1)[1])
+            i += 1
+        return skipped
+    return []
+
+
+def _parse_lock_metadata_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    if not conda_lock_file.exists():
+        return []
+    yaml = YAML(typ="safe")
+    with conda_lock_file.open() as fp:
+        data = yaml.load(fp)
+    if not isinstance(data, dict):
+        return []
+    metadata = data.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return []
+    unidep_metadata = metadata.get("unidep", {})
+    if not isinstance(unidep_metadata, dict):
+        return []
+    skipped = unidep_metadata.get("skipped_dependencies", [])
+    if not isinstance(skipped, list):
+        return []
+    return [str(dependency) for dependency in skipped]
+
+
+def _parse_lock_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+    skipped = _parse_lock_metadata_skipped_dependencies(conda_lock_file)
+    if skipped:
+        return skipped
+    return _parse_lock_header_skipped_dependencies(conda_lock_file)
+
+
+def _filter_env_spec_to_lock_skipped_pip_dependencies(
+    env_spec: CondaEnvironmentSpec,
+    skipped_dependencies: list[str],
+) -> CondaEnvironmentSpec:
+    skipped_names = {
+        _canonical_dependency_name(dependency) for dependency in skipped_dependencies
+    }
+    pip_dependencies = [
+        dependency
+        for dependency in env_spec.pip
+        if _pip_requirement_name(dependency) in skipped_names
+    ]
+    conda_dependencies = [
+        dependency
+        for dependency in env_spec.conda
+        if _conda_dependency_name(dependency) in skipped_names
+    ]
+    if conda_dependencies:
+        dependencies = ", ".join(
+            sorted(str(dependency) for dependency in conda_dependencies),
+        )
+        print(
+            "❌ `conda-lock.yml` was generated with skipped dependencies that"
+            f" resolve to conda packages on this platform: {dependencies}."
+            " `install-all -f` can only repair skipped pip dependencies after"
+            " creating the locked environment. Regenerate the lock without"
+            " skipping those conda dependencies, or run the metadata install"
+            " path without `-f`.",
+        )
+        sys.exit(1)
+    return env_spec._replace(conda=[], pip=pip_dependencies)
 
 
 def _find_lock_key(

--- a/unidep/_conda_lock.py
+++ b/unidep/_conda_lock.py
@@ -23,7 +23,12 @@ from unidep._dependency_selection import (
     collapse_selected_universals,
     select_conda_like_requirements,
 )
-from unidep.utils import add_comment_to_file, remove_top_comments, warn
+from unidep.utils import (
+    add_comment_to_file,
+    parse_package_str,
+    remove_top_comments,
+    warn,
+)
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -82,6 +87,58 @@ def _run_conda_lock(
         sys.exit(1)
 
 
+def _add_unidep_lock_metadata(
+    conda_lock_output: Path,
+    skip_dependencies: list[str],
+) -> None:
+    if not skip_dependencies:
+        return
+    yaml = YAML(typ="rt")
+    yaml.default_flow_style = False
+    yaml.width = 4096
+    with conda_lock_output.open() as fp:
+        data = yaml.load(fp)
+    metadata = data.setdefault("metadata", {})
+    unidep_metadata = metadata.setdefault("unidep", {})
+    unidep_metadata["skipped_dependencies"] = list(dict.fromkeys(skip_dependencies))
+    with conda_lock_output.open("w") as fp:
+        yaml.dump(data, fp)
+
+
+def _ensure_pip_runtime_for_skipped_dependencies(
+    tmp_env: Path,
+    skip_dependencies: list[str],
+) -> None:
+    if not skip_dependencies:
+        return
+    yaml = YAML(typ="rt")
+    yaml.default_flow_style = False
+    yaml.width = 4096
+    with tmp_env.open() as fp:
+        data = yaml.load(fp)
+    dependencies = data.setdefault("dependencies", [])
+    has_pip = any(
+        isinstance(dependency, str) and parse_package_str(dependency).name == "pip"
+        for dependency in dependencies
+    )
+    if has_pip:
+        return
+    pip_section = next(
+        (
+            index
+            for index, dependency in enumerate(dependencies)
+            if isinstance(dependency, dict) and "pip" in dependency
+        ),
+        None,
+    )
+    if pip_section is None:
+        dependencies.append("pip")
+    else:
+        dependencies.insert(pip_section, "pip")
+    with tmp_env.open("w") as fp:
+        yaml.dump(data, fp)
+
+
 def _conda_lock_global(
     *,
     depth: int,
@@ -120,12 +177,14 @@ def _conda_lock_global(
         skip_dependencies=skip_dependencies,
         verbose=verbose,
     )
+    _ensure_pip_runtime_for_skipped_dependencies(tmp_env, skip_dependencies)
     _run_conda_lock(
         tmp_env,
         conda_lock_output,
         check_input_hash=check_input_hash,
         extra_flags=extra_flags,
     )
+    _add_unidep_lock_metadata(conda_lock_output, skip_dependencies)
     print(f"✅ Global dependencies locked successfully in `{conda_lock_output}`.")
     return conda_lock_output
 
@@ -427,6 +486,10 @@ def _conda_lock_subpackage(
         "platforms": platforms,
         "sources": [str(file)],
     }
+    if skip_dependencies:
+        metadata["unidep"] = {
+            "skipped_dependencies": list(dict.fromkeys(skip_dependencies)),
+        }
     with conda_lock_output.open("w") as fp:
         yaml.dump({"version": 1, "metadata": metadata, "package": locked}, fp)
     add_comment_to_file(

--- a/unidep/_conda_lock.py
+++ b/unidep/_conda_lock.py
@@ -351,14 +351,14 @@ def _parse_lock_metadata_skipped_dependencies(conda_lock_file: Path) -> list[str
     return [str(dependency) for dependency in skipped]
 
 
-def _parse_lock_skipped_dependencies(conda_lock_file: Path) -> list[str]:
+def parse_lock_skipped_dependencies(conda_lock_file: Path) -> list[str]:
     skipped = _parse_lock_metadata_skipped_dependencies(conda_lock_file)
     if skipped:
         return skipped
     return _parse_lock_header_skipped_dependencies(conda_lock_file)
 
 
-def _filter_env_spec_to_lock_skipped_pip_dependencies(
+def filter_env_spec_to_lock_skipped_pip_dependencies(
     env_spec: CondaEnvironmentSpec,
     skipped_dependencies: list[str],
 ) -> CondaEnvironmentSpec:


### PR DESCRIPTION
## Summary
- Record `metadata.unidep.skipped_dependencies` in UniDep-generated conda locks.
- In `install-all -f`, repair partial locks by installing skipped pip deps from source metadata while preserving pip indices and editable local deps.
- Keep `pip` in partial lock environments so post-lock pip repair has a Python/pip runtime, and fail early when skipped entries resolve to conda packages.

## Test Plan
- `uv run --extra test pytest tests/test_cli.py::test_install_command_with_partial_conda_lock_installs_skipped_pip_deps tests/test_cli.py::test_parse_lock_skipped_dependencies_from_command_header tests/test_cli.py::test_parse_lock_skipped_dependencies_handles_missing_and_malformed_lock tests/test_cli.py::test_parse_lock_skipped_dependencies_ignores_invalid_metadata_shapes tests/test_cli.py::test_lock_skipped_dependency_name_helpers tests/test_cli.py::test_partial_lock_install_errors_for_skipped_conda_dependencies tests/test_cli.py::test_install_command_with_conda_lock_skips_dependency_install tests/test_conda_lock.py::test_conda_lock_skipped_private_pip_deps_are_not_reported_missing tests/test_conda_lock.py::test_conda_lock_with_only_skipped_pip_deps_keeps_pip_runtime tests/test_conda_lock.py::test_ensure_pip_runtime_for_skipped_dependencies_does_not_duplicate_pip tests/test_cli_install_conda_lock.py --no-cov -q`
- `uv run ruff check --select E501,S105,I001 unidep/_cli.py unidep/_conda_lock.py tests/test_cli.py tests/test_conda_lock.py`
- `git diff --check`
- Broader affected run before this follow-up: `uv run --extra test pytest tests/test_cli.py tests/test_conda_lock.py tests/test_cli_install_conda_lock.py --no-cov -q` -> 114 passed, 5 existing environment-dependent `tests/test_cli.py::test_install_command[...]` cases failed before reaching changed code.
