### PR TITLE
Handle missing Rich in CLI output

### DIFF
--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -45,6 +45,20 @@ def test_rich_class_returns_none_when_rich_is_unavailable(
     assert _cli_output.rich_class("rich.text", "Text") is None
 
 
+def test_rich_class_returns_none_when_rich_parent_package_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def find_spec(name: str) -> object | None:
+        if name == "rich.console":
+            msg = "No module named 'rich'"
+            raise ModuleNotFoundError(msg)
+        return object()
+
+    monkeypatch.setattr(_cli_output.importlib.util, "find_spec", find_spec)
+
+    assert _cli_output.rich_class("rich.console", "Console") is None
+
+
 def test_install_output_auto_console_is_disabled_when_stdout_is_not_tty(
     capsys: pytest.CaptureFixture,
     monkeypatch: pytest.MonkeyPatch,

--- a/unidep/_cli_output.py
+++ b/unidep/_cli_output.py
@@ -10,7 +10,11 @@ from typing import Any
 
 def rich_class(module_name: str, class_name: str) -> Any | None:
     """Return a Rich class if Rich is installed."""
-    if importlib.util.find_spec(module_name) is None:
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except ModuleNotFoundError:
+        return None
+    if spec is None:
         return None
     module = importlib.import_module(module_name)
     return getattr(module, class_name, None)


### PR DESCRIPTION
## Summary
- Treat `ModuleNotFoundError` from optional Rich submodule lookup as Rich being unavailable.
- Keep CLI install phase output on the plain-text fallback path when `rich` is not installed.
- Add a regression test for `find_spec("rich.console")` raising because the parent `rich` package is missing.

Fixes #311

## Test Plan
- [x] `pytest tests/test_cli_output.py tests/test_cli.py::test_print_with_rich_falls_back_when_rich_components_are_unavailable --no-cov -q`
- [x] `ruff check unidep/_cli_output.py tests/test_cli_output.py`
- [x] `MAMBA_ROOT_PREFIX=/home/basnijholt/Code/unidep/.venv CONDA_PREFIX=/home/basnijholt/Code/unidep/.venv pytest --no-cov -q`


<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--312.org.readthedocs.build/en/312/

<!-- readthedocs-preview unidep end -->