### PR TITLE
Add env var command resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,8 +455,7 @@ dependencies:
 
 #### Resolving Environment Variables from Commands
 
-If a private index token can be produced by a command, configure `env_vars` and
-run install commands with `--allow-env-commands`:
+If a private index token can be produced by a command, configure `env_vars`:
 
 ```yaml
 # requirements.yaml
@@ -486,7 +485,7 @@ refresh = "always"
 UniDep captures stdout, strips surrounding whitespace, and uses it as the environment variable value.
 `refresh` defaults to `missing`, which skips the command when the variable already exists.
 Use `refresh: always` for short-lived tokens.
-Commands never run unless `--allow-env-commands` is passed.
+Use `--no-env-commands` to skip configured commands and rely only on existing environment variables.
 
 ### `[project.dependencies]` in `pyproject.toml` handling
 
@@ -907,7 +906,7 @@ usage: unidep install [-h] [-v] [-e] [--skip-local] [--skip-pip]
                       [-n CONDA_ENV_NAME | -p CONDA_ENV_PREFIX] [--dry-run]
                       [--ignore-pin IGNORE_PIN]
                       [--overwrite-pin OVERWRITE_PIN] [-f CONDA_LOCK_FILE]
-                      [--no-uv] [--allow-env-commands]
+                      [--no-uv] [--no-env-commands]
                       files [files ...]
 
 Automatically install all dependencies from one or more `requirements.yaml` or
@@ -975,8 +974,8 @@ options:
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.
-  --allow-env-commands  Allow `env_vars` command entries to run while
-                        resolving installer environment variables.
+  --no-env-commands     Skip `env_vars` command entries while resolving
+                        installer environment variables.
 ```
 
 <!-- OUTPUT:END -->
@@ -1001,7 +1000,7 @@ usage: unidep install [-h] [-v] [-e] [--skip-local] [--skip-pip]
                       [-n CONDA_ENV_NAME | -p CONDA_ENV_PREFIX] [--dry-run]
                       [--ignore-pin IGNORE_PIN]
                       [--overwrite-pin OVERWRITE_PIN] [-f CONDA_LOCK_FILE]
-                      [--no-uv] [--allow-env-commands]
+                      [--no-uv] [--no-env-commands]
                       files [files ...]
 
 Automatically install all dependencies from one or more `requirements.yaml` or
@@ -1069,8 +1068,8 @@ options:
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.
-  --allow-env-commands  Allow `env_vars` command entries to run while
-                        resolving installer environment variables.
+  --no-env-commands     Skip `env_vars` command entries while resolving
+                        installer environment variables.
 ```
 
 <!-- OUTPUT:END -->

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ usage: unidep install [-h] [-v] [-e] [--skip-local] [--skip-pip]
                       [-n CONDA_ENV_NAME | -p CONDA_ENV_PREFIX] [--dry-run]
                       [--ignore-pin IGNORE_PIN]
                       [--overwrite-pin OVERWRITE_PIN] [-f CONDA_LOCK_FILE]
-                      [--no-uv]
+                      [--no-uv] [--allow-env-commands]
                       files [files ...]
 
 Automatically install all dependencies from one or more `requirements.yaml` or
@@ -975,6 +975,8 @@ options:
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.
+  --allow-env-commands  Allow `env_vars` command entries to run while
+                        resolving installer environment variables.
 ```
 
 <!-- OUTPUT:END -->
@@ -999,7 +1001,7 @@ usage: unidep install [-h] [-v] [-e] [--skip-local] [--skip-pip]
                       [-n CONDA_ENV_NAME | -p CONDA_ENV_PREFIX] [--dry-run]
                       [--ignore-pin IGNORE_PIN]
                       [--overwrite-pin OVERWRITE_PIN] [-f CONDA_LOCK_FILE]
-                      [--no-uv]
+                      [--no-uv] [--allow-env-commands]
                       files [files ...]
 
 Automatically install all dependencies from one or more `requirements.yaml` or
@@ -1067,6 +1069,8 @@ options:
                         env-name` or `--conda-env-prefix`.
   --no-uv               Disables the use of `uv` for pip install. By default,
                         `uv` is used if it is available in the PATH.
+  --allow-env-commands  Allow `env_vars` command entries to run while
+                        resolving installer environment variables.
 ```
 
 <!-- OUTPUT:END -->

--- a/README.md
+++ b/README.md
@@ -452,6 +452,41 @@ dependencies:
 > [!TIP]
 > Store sensitive credentials in environment variables rather than hardcoding them in configuration files. UniDep validates `${VAR_NAME}` patterns and expands them only when invoking installers.
 
+#### Resolving Environment Variables from Commands
+
+If a private index token can be produced by a command, configure `env_vars` and
+run install commands with `--allow-env-commands`:
+
+```yaml
+# requirements.yaml
+env_vars:
+  PRIVATE_REPO_TOKEN:
+    command:
+      - gcloud
+      - auth
+      - print-access-token
+    refresh: always
+
+pip_indices:
+  - https://token:${PRIVATE_REPO_TOKEN}@private.example.com/simple/
+```
+
+```toml
+# pyproject.toml
+[tool.unidep]
+pip_indices = ["https://token:${PRIVATE_REPO_TOKEN}@private.example.com/simple/"]
+
+[tool.unidep.env_vars.PRIVATE_REPO_TOKEN]
+command = ["gcloud", "auth", "print-access-token"]
+refresh = "always"
+```
+
+`command` must be a list of arguments, not a shell string. UniDep captures
+stdout, strips surrounding whitespace, and uses it as the environment variable
+value. `refresh` defaults to `missing`, which skips the command when the variable
+already exists. Use `refresh: always` for short-lived tokens. Commands never run
+unless `--allow-env-commands` is passed.
+
 ### `[project.dependencies]` in `pyproject.toml` handling
 
 The `project_dependency_handling` option in `[tool.unidep]` (in `pyproject.toml`) controls how dependencies listed in the standard `[project.dependencies]` section of `pyproject.toml` are handled when processed by `unidep`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Try it now and streamline your development process!
     - [How It Works](#how-it-works-1)
     - [Example Usage](#example-usage)
     - [Generated Output](#generated-output)
+    - [Resolving Environment Variables from Commands](#resolving-environment-variables-from-commands)
   - [`[project.dependencies]` in `pyproject.toml` handling](#projectdependencies-in-pyprojecttoml-handling)
 - [:jigsaw: Build System Integration](#jigsaw-build-system-integration)
   - [Local Dependencies in Monorepos](#local-dependencies-in-monorepos)

--- a/README.md
+++ b/README.md
@@ -482,11 +482,11 @@ command = ["gcloud", "auth", "print-access-token"]
 refresh = "always"
 ```
 
-`command` must be a list of arguments, not a shell string. UniDep captures
-stdout, strips surrounding whitespace, and uses it as the environment variable
-value. `refresh` defaults to `missing`, which skips the command when the variable
-already exists. Use `refresh: always` for short-lived tokens. Commands never run
-unless `--allow-env-commands` is passed.
+`command` must be a list of arguments, not a shell string.
+UniDep captures stdout, strips surrounding whitespace, and uses it as the environment variable value.
+`refresh` defaults to `missing`, which skips the command when the variable already exists.
+Use `refresh: always` for short-lived tokens.
+Commands never run unless `--allow-env-commands` is passed.
 
 ### `[project.dependencies]` in `pyproject.toml` handling
 

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING, Any
@@ -129,6 +130,102 @@ def test_install_no_env_commands_skips_command_and_reports_missing_var(
         )
 
     env_run.assert_not_called()
+
+
+def test_install_dry_run_does_not_run_env_var_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run") as env_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=True,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+        )
+
+    out = capsys.readouterr().out
+    env_run.assert_not_called()
+    assert "https://***@private.example.com/simple/" in out
+    assert "PRIVATE_REPO_TOKEN" not in os.environ
+
+
+def test_install_no_dependencies_does_not_run_env_var_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run") as env_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=False,
+            no_dependencies=True,
+            no_uv=True,
+            verbose=False,
+        )
+
+    env_run.assert_not_called()
+    assert "PRIVATE_REPO_TOKEN" not in os.environ
+
+
+def test_install_skip_pip_and_local_does_not_run_env_var_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run") as env_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=True,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+        )
+
+    env_run.assert_not_called()
+    assert "PRIVATE_REPO_TOKEN" not in os.environ
 
 
 def test_install_keeps_existing_env_var_by_default(

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -14,10 +14,10 @@ from unidep._dependencies_parsing import parse_requirements
 from unidep._env_vars import (
     EnvVarCommand,
     EnvVarCommandError,
-    EnvVarCommandPermissionError,
     collect_env_vars,
     resolve_env_var_commands,
 )
+from unidep._pip_indices import MissingPipIndexEnvironmentVariablesError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -84,7 +84,6 @@ def test_install_resolves_missing_pip_index_env_var_from_command(
             no_dependencies=False,
             no_uv=True,
             verbose=False,
-            allow_env_commands=True,
         )
 
     out = capsys.readouterr().out
@@ -97,7 +96,7 @@ def test_install_resolves_missing_pip_index_env_var_from_command(
     )
 
 
-def test_install_requires_allow_env_commands_before_running_command(
+def test_install_no_env_commands_skips_command_and_reports_missing_var(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -107,7 +106,10 @@ def test_install_requires_allow_env_commands_before_running_command(
     with (
         patch("unidep._cli._maybe_conda_executable", return_value=None),
         patch("unidep._env_vars.subprocess.run") as env_run,
-        pytest.raises(EnvVarCommandPermissionError, match="--allow-env-commands"),
+        pytest.raises(
+            MissingPipIndexEnvironmentVariablesError,
+            match="PRIVATE_REPO_TOKEN",
+        ),
     ):
         _install_command(
             req_file,
@@ -123,6 +125,7 @@ def test_install_requires_allow_env_commands_before_running_command(
             no_dependencies=False,
             no_uv=True,
             verbose=False,
+            no_env_commands=True,
         )
 
     env_run.assert_not_called()
@@ -197,7 +200,6 @@ def test_install_refresh_always_replaces_existing_env_var(
             no_dependencies=False,
             no_uv=True,
             verbose=False,
-            allow_env_commands=True,
         )
 
     assert (
@@ -307,7 +309,7 @@ def test_resolve_env_var_command_reports_failed_command(
     ):
         resolve_env_var_commands(
             {"TOKEN": EnvVarCommand(command=("cmd",))},
-            allow_commands=True,
+            no_env_commands=False,
         )
 
 
@@ -325,11 +327,11 @@ def test_resolve_env_var_command_reports_empty_output(
     ):
         resolve_env_var_commands(
             {"TOKEN": EnvVarCommand(command=("cmd",))},
-            allow_commands=True,
+            no_env_commands=False,
         )
 
 
-def test_install_cli_reports_env_var_command_permission_error(
+def test_install_cli_no_env_commands_reports_missing_var(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
@@ -347,6 +349,7 @@ def test_install_cli_reports_env_var_command_permission_error(
             "--skip-local",
             "--conda-env-name",
             "test-env",
+            "--no-env-commands",
         ],
     )
 
@@ -355,5 +358,5 @@ def test_install_cli_reports_env_var_command_permission_error(
 
     captured = capsys.readouterr()
     assert excinfo.value.code == 1
-    assert "--allow-env-commands" in captured.err
+    assert "Unresolved environment variable(s) PRIVATE_REPO_TOKEN" in captured.err
     assert "Traceback" not in captured.err

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -1,0 +1,359 @@
+"""Tests for resolving installer environment variables from commands."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from unidep._cli import _install_command, main
+from unidep._dependencies_parsing import parse_requirements
+from unidep._env_vars import (
+    EnvVarCommand,
+    EnvVarCommandError,
+    EnvVarCommandPermissionError,
+    collect_env_vars,
+    resolve_env_var_commands,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def _write_private_index_project(
+    tmp_path: Path,
+    *,
+    refresh: str | None = None,
+) -> Path:
+    refresh_config = "" if refresh is None else f"    refresh: {refresh}\n"
+    req_file = tmp_path / "requirements.yaml"
+    req_file.write_text(
+        f"""\
+name: test_project
+env_vars:
+  PRIVATE_REPO_TOKEN:
+    command:
+      - gcloud
+      - auth
+      - print-access-token
+{refresh_config}pip_indices:
+  - https://token:${{PRIVATE_REPO_TOKEN}}@private.example.com/simple/
+dependencies:
+  - pip: private-package
+""",
+    )
+    return req_file
+
+
+def test_install_resolves_missing_pip_index_env_var_from_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+
+    def run(
+        command: Sequence[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        if tuple(command) == ("gcloud", "auth", "print-access-token"):
+            return subprocess.CompletedProcess(command, 0, stdout="synthetic-token\n")
+        raise AssertionError(command)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run", side_effect=run) as env_run,
+        patch("unidep._cli._run_with_redacted_command") as pip_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+            allow_env_commands=True,
+        )
+
+    out = capsys.readouterr().out
+    assert env_run.call_args[0][0] == ("gcloud", "auth", "print-access-token")
+    assert "synthetic-token" not in out
+    assert "https://***@private.example.com/simple/" in out
+    assert (
+        "https://token:synthetic-token@private.example.com/simple/"
+        in pip_run.call_args[0][0]
+    )
+
+
+def test_install_requires_allow_env_commands_before_running_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run") as env_run,
+        pytest.raises(EnvVarCommandPermissionError, match="--allow-env-commands"),
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+        )
+
+    env_run.assert_not_called()
+
+
+def test_install_keeps_existing_env_var_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PRIVATE_REPO_TOKEN", "existing-token")
+    req_file = _write_private_index_project(tmp_path)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run") as env_run,
+        patch("unidep._cli._run_with_redacted_command") as pip_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+        )
+
+    env_run.assert_not_called()
+    assert (
+        "https://token:existing-token@private.example.com/simple/"
+        in pip_run.call_args[0][0]
+    )
+
+
+def test_install_refresh_always_replaces_existing_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PRIVATE_REPO_TOKEN", "stale-token")
+    req_file = _write_private_index_project(tmp_path, refresh="always")
+
+    def run(
+        command: Sequence[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        if tuple(command) == ("gcloud", "auth", "print-access-token"):
+            return subprocess.CompletedProcess(command, 0, stdout="fresh-token\n")
+        raise AssertionError(command)
+
+    with (
+        patch("unidep._cli._maybe_conda_executable", return_value=None),
+        patch("unidep._env_vars.subprocess.run", side_effect=run),
+        patch("unidep._cli._run_with_redacted_command") as pip_run,
+    ):
+        _install_command(
+            req_file,
+            conda_executable=None,
+            conda_env_name=None,
+            conda_env_prefix=None,
+            conda_lock_file=None,
+            dry_run=False,
+            editable=False,
+            skip_local=True,
+            skip_pip=False,
+            skip_conda=True,
+            no_dependencies=False,
+            no_uv=True,
+            verbose=False,
+            allow_env_commands=True,
+        )
+
+    assert (
+        "https://token:fresh-token@private.example.com/simple/"
+        in pip_run.call_args[0][0]
+    )
+
+
+def test_parse_env_vars_from_pyproject(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """\
+[tool.unidep]
+dependencies = [{ pip = "private-package" }]
+pip_indices = ["https://token:${PRIVATE_REPO_TOKEN}@private.example.com/simple/"]
+
+[tool.unidep.env_vars.PRIVATE_REPO_TOKEN]
+command = ["gcloud", "auth", "print-access-token"]
+refresh = "always"
+""",
+    )
+
+    parsed = parse_requirements(pyproject)
+
+    assert parsed.env_vars == {
+        "PRIVATE_REPO_TOKEN": EnvVarCommand(
+            command=("gcloud", "auth", "print-access-token"),
+            refresh="always",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("config", "error_type", "match"),
+    [
+        ({"env_vars": []}, TypeError, "`env_vars` must be a mapping."),
+        (
+            {"env_vars": {"1BAD": {"command": ["echo"]}}},
+            ValueError,
+            "`env_vars` keys must be valid environment variable names.",
+        ),
+        (
+            {"env_vars": {"TOKEN": "echo token"}},
+            TypeError,
+            "`env_vars.TOKEN` must be a mapping.",
+        ),
+        (
+            {"env_vars": {"TOKEN": {"command": "echo token"}}},
+            TypeError,
+            "`env_vars.TOKEN.command` must be a non-empty list of strings.",
+        ),
+        (
+            {"env_vars": {"TOKEN": {"command": ["echo"], "refresh": "never"}}},
+            ValueError,
+            "`env_vars.TOKEN.refresh` must be 'missing' or 'always'.",
+        ),
+    ],
+)
+def test_collect_env_vars_rejects_invalid_config(
+    config: dict[str, Any],
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error_type, match=match):
+        collect_env_vars(config)
+
+
+def test_parse_requirements_rejects_conflicting_env_var_definitions(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text(
+        """\
+env_vars:
+  TOKEN:
+    command: ["echo", "first"]
+dependencies:
+  - pip: private-package
+""",
+    )
+    second.write_text(
+        """\
+env_vars:
+  TOKEN:
+    command: ["echo", "second"]
+dependencies:
+  - pip: other-private-package
+""",
+    )
+
+    with pytest.raises(ValueError, match="Conflicting `env_vars` definitions"):
+        parse_requirements(first, second)
+
+
+def test_resolve_env_var_command_reports_failed_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TOKEN", raising=False)
+
+    with (
+        patch(
+            "unidep._env_vars.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, ("cmd",)),
+        ),
+        pytest.raises(EnvVarCommandError, match="failed to resolve a value"),
+    ):
+        resolve_env_var_commands(
+            {"TOKEN": EnvVarCommand(command=("cmd",))},
+            allow_commands=True,
+        )
+
+
+def test_resolve_env_var_command_reports_empty_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TOKEN", raising=False)
+
+    with (
+        patch(
+            "unidep._env_vars.subprocess.run",
+            return_value=subprocess.CompletedProcess(("cmd",), 0, stdout="\n"),
+        ),
+        pytest.raises(EnvVarCommandError, match="produced no output"),
+    ):
+        resolve_env_var_commands(
+            {"TOKEN": EnvVarCommand(command=("cmd",))},
+            allow_commands=True,
+        )
+
+
+def test_install_cli_reports_env_var_command_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+    req_file = _write_private_index_project(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "unidep",
+            "install",
+            str(req_file),
+            "--skip-conda",
+            "--skip-local",
+            "--conda-env-name",
+            "test-env",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "--allow-env-commands" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -18,7 +18,10 @@ from unidep._env_vars import (
     collect_env_vars,
     resolve_env_var_commands,
 )
-from unidep._pip_indices import MissingPipIndexEnvironmentVariablesError
+from unidep._pip_indices import (
+    MissingPipIndexEnvironmentVariablesError,
+    normalize_pip_indices,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -226,6 +229,17 @@ def test_install_skip_pip_and_local_does_not_run_env_var_command(
 
     env_run.assert_not_called()
     assert "PRIVATE_REPO_TOKEN" not in os.environ
+
+
+def test_normalize_string_can_skip_environment_variable_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
+
+    assert normalize_pip_indices(
+        "https://${PRIVATE_REPO_TOKEN}@private.example.com/simple/",
+        validate_env_vars=False,
+    ) == ("https://${PRIVATE_REPO_TOKEN}@private.example.com/simple/",)
 
 
 def test_install_keeps_existing_env_var_by_default(

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -18,10 +18,7 @@ from unidep._env_vars import (
     collect_env_vars,
     resolve_env_var_commands,
 )
-from unidep._pip_indices import (
-    MissingPipIndexEnvironmentVariablesError,
-    normalize_pip_indices,
-)
+from unidep._pip_indices import MissingPipIndexEnvironmentVariablesError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -229,17 +226,6 @@ def test_install_skip_pip_and_local_does_not_run_env_var_command(
 
     env_run.assert_not_called()
     assert "PRIVATE_REPO_TOKEN" not in os.environ
-
-
-def test_normalize_string_can_skip_environment_variable_validation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("PRIVATE_REPO_TOKEN", raising=False)
-
-    assert normalize_pip_indices(
-        "https://${PRIVATE_REPO_TOKEN}@private.example.com/simple/",
-        validate_env_vars=False,
-    ) == ("https://${PRIVATE_REPO_TOKEN}@private.example.com/simple/",)
 
 
 def test_install_keeps_existing_env_var_by_default(

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -37,10 +37,7 @@ from unidep._dependencies_parsing import (
     parse_requirements,
 )
 from unidep._doctor import run_doctor_command
-from unidep._env_vars import (
-    EnvVarCommandError,
-    resolve_env_var_commands,
-)
+from unidep._env_vars import EnvVarCommandError, resolve_env_var_commands
 from unidep._pip_indices import (
     MissingPipIndexEnvironmentVariablesError,
     build_pip_index_arguments,

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -1169,7 +1169,10 @@ def _pip_install_local(
     pip_indices: Sequence[str] | None = None,
     flags: list[str] | None = None,
 ) -> None:  # pragma: no cover
-    index_args = build_pip_index_arguments(pip_indices or [])
+    index_args = build_pip_index_arguments(
+        pip_indices or [],
+        expand_env_vars=not dry_run,
+    )
     if _use_uv(no_uv):
         pip_command = [
             *conda_run,
@@ -1294,12 +1297,6 @@ def _install_command(  # noqa: PLR0912, PLR0915
         verbose=verbose,
         extras=[f.extras for f in paths_with_extras],
     )
-    os.environ.update(
-        resolve_env_var_commands(
-            requirements.env_vars or {},
-            no_env_commands=no_env_commands,
-        ),
-    )
     platforms = [identify_current_platform()]
     env_entries = _flatten_selected_dependency_entries(
         requirements.dependency_entries,
@@ -1310,7 +1307,10 @@ def _install_command(  # noqa: PLR0912, PLR0915
         requirements.channels,
         requirements.pip_indices,
         platforms=platforms,
+        validate_pip_index_env_vars=False,
     )
+    if dry_run and env_spec.pip_indices and not requirements.env_vars:
+        build_pip_index_arguments(env_spec.pip_indices)
     if not conda_executable:  # None or empty string
         conda_executable = _maybe_conda_executable()
     if conda_lock_file:  # As late as possible to error out early in previous steps
@@ -1335,6 +1335,18 @@ def _install_command(  # noqa: PLR0912, PLR0915
         local_paths = _collect_installable_local_paths(
             paths_with_extras,
             verbose=verbose,
+        )
+    if (
+        env_spec.pip_indices
+        and not dry_run
+        and not no_dependencies
+        and ((env_spec.pip and not skip_pip) or local_paths.all_paths)
+    ):
+        os.environ.update(
+            resolve_env_var_commands(
+                requirements.env_vars or {},
+                no_env_commands=no_env_commands,
+            ),
         )
     conda_dependencies = _conda_dependencies_with_required_pip(
         env_spec.conda,
@@ -1372,14 +1384,18 @@ def _install_command(  # noqa: PLR0912, PLR0915
         )
         if not dry_run:  # pragma: no cover
             subprocess.run((*conda_command, *conda_dependencies), check=True)
-    python_executable = _python_executable(
-        conda_executable,
-        conda_env_name,
-        conda_env_prefix,
-    )
+    python_executable: str | None = None
     if env_spec.pip and not skip_pip:
         conda_run = _maybe_conda_run(conda_executable, conda_env_name, conda_env_prefix)
-        index_args = build_pip_index_arguments(env_spec.pip_indices)
+        index_args = build_pip_index_arguments(
+            env_spec.pip_indices,
+            expand_env_vars=not dry_run,
+        )
+        python_executable = _python_executable(
+            conda_executable,
+            conda_env_name,
+            conda_env_prefix,
+        )
         use_uv = _use_uv(no_uv)
         # uv resolves the whole command up front. Local dependencies must be
         # direct requirements here; the later --no-deps editable install is too
@@ -1427,6 +1443,12 @@ def _install_command(  # noqa: PLR0912, PLR0915
             conda_env_name,
             conda_env_prefix,
         )
+        if python_executable is None:
+            python_executable = _python_executable(
+                conda_executable,
+                conda_env_name,
+                conda_env_prefix,
+            )
         _pip_install_local(
             *sorted(local_paths.all_paths),
             editable=editable,
@@ -1434,7 +1456,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
             python_executable=python_executable,
             flags=pip_flags,
             no_uv=no_uv,
-            pip_indices=env_spec.pip_indices,
+            pip_indices=() if no_dependencies else env_spec.pip_indices,
             conda_run=conda_run,
         )
 

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -37,6 +37,11 @@ from unidep._dependencies_parsing import (
     parse_requirements,
 )
 from unidep._doctor import run_doctor_command
+from unidep._env_vars import (
+    EnvVarCommandError,
+    EnvVarCommandPermissionError,
+    resolve_env_var_commands,
+)
 from unidep._pip_indices import (
     MissingPipIndexEnvironmentVariablesError,
     build_pip_index_arguments,
@@ -353,6 +358,13 @@ def _add_common_args(  # noqa: PLR0912, C901
             help="Disables the use of `uv` for pip install. By default, `uv` is used"
             " if it is available in the PATH.",
         )
+    if "allow-env-commands" in options:
+        sub_parser.add_argument(
+            "--allow-env-commands",
+            action="store_true",
+            help="Allow `env_vars` command entries to run while resolving installer"
+            " environment variables.",
+        )
 
 
 def _add_extra_flags(
@@ -497,6 +509,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "skip-dependency",
             "overwrite-pin",
             "no-uv",
+            "allow-env-commands",
             "verbose",
         },
     )
@@ -541,6 +554,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "skip-dependency",
             "overwrite-pin",
             "no-uv",
+            "allow-env-commands",
             "verbose",
         },
     )
@@ -1267,6 +1281,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
     no_uv: bool = True,
+    allow_env_commands: bool = False,
     verbose: bool = False,
 ) -> None:
     """Install the dependencies of a single `requirements.yaml` or `pyproject.toml` file."""  # noqa: E501
@@ -1279,6 +1294,12 @@ def _install_command(  # noqa: PLR0912, PLR0915
         skip_dependencies=skip_dependencies,
         verbose=verbose,
         extras=[f.extras for f in paths_with_extras],
+    )
+    os.environ.update(
+        resolve_env_var_commands(
+            requirements.env_vars or {},
+            allow_commands=allow_env_commands,
+        ),
     )
     platforms = [identify_current_platform()]
     env_entries = _flatten_selected_dependency_entries(
@@ -1442,6 +1463,7 @@ def _install_all_command(
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
     no_uv: bool = True,
+    allow_env_commands: bool = False,
     verbose: bool = False,
 ) -> None:  # pragma: no cover
     found_files = find_requirements_files(
@@ -1468,6 +1490,7 @@ def _install_all_command(
         overwrite_pins=overwrite_pins,
         skip_dependencies=skip_dependencies,
         no_uv=no_uv,
+        allow_env_commands=allow_env_commands,
         verbose=verbose,
     )
 
@@ -1964,6 +1987,7 @@ def _main() -> None:  # noqa: PLR0912
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
             no_uv=args.no_uv,
+            allow_env_commands=args.allow_env_commands,
             verbose=args.verbose,
         )
     elif args.command == "install-all":
@@ -1986,6 +2010,7 @@ def _main() -> None:  # noqa: PLR0912
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
             no_uv=args.no_uv,
+            allow_env_commands=args.allow_env_commands,
             verbose=args.verbose,
         )
     elif args.command == "conda-lock":  # pragma: no cover
@@ -2053,6 +2078,10 @@ def main() -> None:
     """Run the command-line tool with user-facing error reporting."""
     try:
         _main()
-    except MissingPipIndexEnvironmentVariablesError as error:
+    except (
+        MissingPipIndexEnvironmentVariablesError,
+        EnvVarCommandError,
+        EnvVarCommandPermissionError,
+    ) as error:
         print(f"❌ {error}", file=sys.stderr)
         sys.exit(1)

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -39,7 +39,6 @@ from unidep._dependencies_parsing import (
 from unidep._doctor import run_doctor_command
 from unidep._env_vars import (
     EnvVarCommandError,
-    EnvVarCommandPermissionError,
     resolve_env_var_commands,
 )
 from unidep._pip_indices import (
@@ -358,11 +357,11 @@ def _add_common_args(  # noqa: PLR0912, C901
             help="Disables the use of `uv` for pip install. By default, `uv` is used"
             " if it is available in the PATH.",
         )
-    if "allow-env-commands" in options:
+    if "no-env-commands" in options:
         sub_parser.add_argument(
-            "--allow-env-commands",
+            "--no-env-commands",
             action="store_true",
-            help="Allow `env_vars` command entries to run while resolving installer"
+            help="Skip `env_vars` command entries while resolving installer"
             " environment variables.",
         )
 
@@ -509,7 +508,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "skip-dependency",
             "overwrite-pin",
             "no-uv",
-            "allow-env-commands",
+            "no-env-commands",
             "verbose",
         },
     )
@@ -554,7 +553,7 @@ def _parse_args() -> argparse.Namespace:  # noqa: PLR0915
             "skip-dependency",
             "overwrite-pin",
             "no-uv",
-            "allow-env-commands",
+            "no-env-commands",
             "verbose",
         },
     )
@@ -1281,7 +1280,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
     no_uv: bool = True,
-    allow_env_commands: bool = False,
+    no_env_commands: bool = False,
     verbose: bool = False,
 ) -> None:
     """Install the dependencies of a single `requirements.yaml` or `pyproject.toml` file."""  # noqa: E501
@@ -1298,7 +1297,7 @@ def _install_command(  # noqa: PLR0912, PLR0915
     os.environ.update(
         resolve_env_var_commands(
             requirements.env_vars or {},
-            allow_commands=allow_env_commands,
+            no_env_commands=no_env_commands,
         ),
     )
     platforms = [identify_current_platform()]
@@ -1463,7 +1462,7 @@ def _install_all_command(
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
     no_uv: bool = True,
-    allow_env_commands: bool = False,
+    no_env_commands: bool = False,
     verbose: bool = False,
 ) -> None:  # pragma: no cover
     found_files = find_requirements_files(
@@ -1490,7 +1489,7 @@ def _install_all_command(
         overwrite_pins=overwrite_pins,
         skip_dependencies=skip_dependencies,
         no_uv=no_uv,
-        allow_env_commands=allow_env_commands,
+        no_env_commands=no_env_commands,
         verbose=verbose,
     )
 
@@ -1987,7 +1986,7 @@ def _main() -> None:  # noqa: PLR0912
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
             no_uv=args.no_uv,
-            allow_env_commands=args.allow_env_commands,
+            no_env_commands=args.no_env_commands,
             verbose=args.verbose,
         )
     elif args.command == "install-all":
@@ -2010,7 +2009,7 @@ def _main() -> None:  # noqa: PLR0912
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
             no_uv=args.no_uv,
-            allow_env_commands=args.allow_env_commands,
+            no_env_commands=args.no_env_commands,
             verbose=args.verbose,
         )
     elif args.command == "conda-lock":  # pragma: no cover
@@ -2081,7 +2080,6 @@ def main() -> None:
     except (
         MissingPipIndexEnvironmentVariablesError,
         EnvVarCommandError,
-        EnvVarCommandPermissionError,
     ) as error:
         print(f"❌ {error}", file=sys.stderr)
         sys.exit(1)

--- a/unidep/_conda_env.py
+++ b/unidep/_conda_env.py
@@ -138,6 +138,7 @@ def create_conda_env_specification(  # noqa: C901, PLR0912, PLR0915
     platforms: Sequence[Platform] | None = None,
     selector: Literal["sel", "comment"] = "sel",
     pip_indices: Sequence[str] | None = None,
+    validate_pip_index_env_vars: bool = True,
 ) -> CondaEnvironmentSpec:
     """Create a conda environment specification from dependency entries.
 
@@ -195,7 +196,10 @@ def create_conda_env_specification(  # noqa: C901, PLR0912, PLR0915
 
     entries = _as_dependency_entries(entries)
     conda, pip = _extract_conda_pip_dependencies(entries, resolved_platforms)
-    normalized_pip_indices = normalize_pip_indices(pip_indices)
+    normalized_pip_indices = normalize_pip_indices(
+        pip_indices,
+        validate_env_vars=validate_pip_index_env_vars,
+    )
 
     conda_deps: list[str | dict[str, str]] = CommentedSeq()
     pip_deps: list[str] = CommentedSeq()

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -19,6 +19,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from unidep._conflicts import extract_version_operator
+from unidep._env_vars import EnvVarCommand, collect_env_vars
 from unidep._version import __version__
 from unidep.platform_definitions import Platform, Spec, platforms_from_selector
 from unidep.utils import (
@@ -164,6 +165,7 @@ class ParsedRequirements(NamedTuple):
     dependency_entries: list[DependencyEntry]
     optional_dependency_entries: dict[str, list[DependencyEntry]]
     pip_indices: tuple[str, ...] = ()
+    env_vars: dict[str, EnvVarCommand] | None = None
 
 
 class Requirements(NamedTuple):
@@ -699,6 +701,7 @@ def parse_requirements(
     optional_dependency_entries: dict[str, list[DependencyEntry]] = defaultdict(list)
     channels: set[str] = set()
     pip_indices: list[str] = []  # Preserve order, first is primary
+    env_vars: dict[str, EnvVarCommand] = {}
     platforms: set[Platform] = set()
 
     identifier = -1
@@ -709,6 +712,11 @@ def parse_requirements(
         for index in _collect_pip_indices(data):
             if index and index not in pip_indices:
                 pip_indices.append(index)
+        for name, command in collect_env_vars(data).items():
+            if name in env_vars and env_vars[name] != command:
+                msg = f"Conflicting `env_vars` definitions for {name}."
+                raise ValueError(msg)
+            env_vars[name] = command
         platforms.update(data.get("platforms", []))
         if "dependencies" in data:
             identifier = _add_dependencies(
@@ -746,6 +754,7 @@ def parse_requirements(
         dependency_entries,
         defaultdict_to_dict(optional_dependency_entries),
         tuple(pip_indices),
+        dict(env_vars),
     )
 
 

--- a/unidep/_env_vars.py
+++ b/unidep/_env_vars.py
@@ -1,0 +1,111 @@
+"""Helpers for resolving environment variables from configured commands."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+RefreshPolicy = Literal["missing", "always"]
+
+_ENV_VAR_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class EnvVarCommandError(RuntimeError):
+    """Raised when an env var command cannot produce a value."""
+
+
+class EnvVarCommandPermissionError(PermissionError):
+    """Raised when env var commands are configured but not allowed."""
+
+
+@dataclass(frozen=True)
+class EnvVarCommand:
+    """Command that can provide an environment variable value."""
+
+    command: tuple[str, ...]
+    refresh: RefreshPolicy = "missing"
+
+
+def collect_env_vars(data: Mapping[str, Any]) -> dict[str, EnvVarCommand]:
+    """Collect env var command definitions from the unidep config."""
+    raw_env_vars = data.get("env_vars")
+    if raw_env_vars is None:
+        return {}
+    if not isinstance(raw_env_vars, Mapping):
+        msg = "`env_vars` must be a mapping."
+        raise TypeError(msg)
+
+    env_vars: dict[str, EnvVarCommand] = {}
+    for name, raw_config in raw_env_vars.items():
+        if not isinstance(name, str) or not _ENV_VAR_NAME.fullmatch(name):
+            msg = "`env_vars` keys must be valid environment variable names."
+            raise ValueError(msg)
+        if not isinstance(raw_config, Mapping):
+            msg = f"`env_vars.{name}` must be a mapping."
+            raise TypeError(msg)
+        raw_command = raw_config.get("command")
+        if (
+            isinstance(raw_command, str)
+            or not isinstance(raw_command, Sequence)
+            or not raw_command
+            or any(not isinstance(part, str) or not part for part in raw_command)
+        ):
+            msg = f"`env_vars.{name}.command` must be a non-empty list of strings."
+            raise TypeError(msg)
+        raw_refresh = raw_config.get("refresh", "missing")
+        if raw_refresh not in {"missing", "always"}:
+            msg = f"`env_vars.{name}.refresh` must be 'missing' or 'always'."
+            raise ValueError(msg)
+        env_vars[name] = EnvVarCommand(
+            command=tuple(raw_command),
+            refresh=cast("RefreshPolicy", raw_refresh),
+        )
+    return env_vars
+
+
+def resolve_env_var_commands(
+    env_vars: Mapping[str, EnvVarCommand],
+    *,
+    allow_commands: bool,
+) -> dict[str, str]:
+    """Run configured commands and return resolved environment variable values."""
+    to_resolve = {
+        name: config
+        for name, config in env_vars.items()
+        if config.refresh == "always" or name not in os.environ
+    }
+    if not to_resolve:
+        return {}
+    if not allow_commands:
+        names = ", ".join(sorted(to_resolve))
+        msg = (
+            f"env_vars command(s) configured for {names}. Re-run with "
+            "`--allow-env-commands` to execute them."
+        )
+        raise EnvVarCommandPermissionError(msg)
+    return {
+        name: _run_env_var_command(name, config) for name, config in to_resolve.items()
+    }
+
+
+def _run_env_var_command(name: str, config: EnvVarCommand) -> str:
+    try:
+        completed = subprocess.run(
+            config.command,
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        msg = f"`env_vars.{name}.command` failed to resolve a value."
+        raise EnvVarCommandError(msg) from error
+    value = completed.stdout.strip()
+    if not value:
+        msg = f"`env_vars.{name}.command` produced no output."
+        raise EnvVarCommandError(msg)
+    return value

--- a/unidep/_env_vars.py
+++ b/unidep/_env_vars.py
@@ -18,10 +18,6 @@ class EnvVarCommandError(RuntimeError):
     """Raised when an env var command cannot produce a value."""
 
 
-class EnvVarCommandPermissionError(PermissionError):
-    """Raised when env var commands are configured but not allowed."""
-
-
 @dataclass(frozen=True)
 class EnvVarCommand:
     """Command that can provide an environment variable value."""
@@ -70,9 +66,11 @@ def collect_env_vars(data: Mapping[str, Any]) -> dict[str, EnvVarCommand]:
 def resolve_env_var_commands(
     env_vars: Mapping[str, EnvVarCommand],
     *,
-    allow_commands: bool,
+    no_env_commands: bool,
 ) -> dict[str, str]:
     """Run configured commands and return resolved environment variable values."""
+    if no_env_commands:
+        return {}
     to_resolve = {
         name: config
         for name, config in env_vars.items()
@@ -80,13 +78,6 @@ def resolve_env_var_commands(
     }
     if not to_resolve:
         return {}
-    if not allow_commands:
-        names = ", ".join(sorted(to_resolve))
-        msg = (
-            f"env_vars command(s) configured for {names}. Re-run with "
-            "`--allow-env-commands` to execute them."
-        )
-        raise EnvVarCommandPermissionError(msg)
     return {
         name: _run_env_var_command(name, config) for name, config in to_resolve.items()
     }

--- a/unidep/_pip_indices.py
+++ b/unidep/_pip_indices.py
@@ -56,8 +56,6 @@ def normalize_pip_indices(
     if pip_indices is None:
         return ()
     if not validate_env_vars:
-        if isinstance(pip_indices, str):
-            return (pip_indices,)
         return tuple(pip_indices)
     if isinstance(pip_indices, str):
         return _validate_pip_indices_env_vars((pip_indices,))

--- a/unidep/_pip_indices.py
+++ b/unidep/_pip_indices.py
@@ -47,22 +47,38 @@ def _expand_pip_indices_for_installer(pip_indices: Sequence[str]) -> tuple[str, 
     return tuple(os.path.expandvars(index) for index in pip_indices)
 
 
-def normalize_pip_indices(pip_indices: Sequence[str] | None) -> tuple[str, ...]:
+def normalize_pip_indices(
+    pip_indices: Sequence[str] | None,
+    *,
+    validate_env_vars: bool = True,
+) -> tuple[str, ...]:
     """Normalize configured pip index URLs without expanding secrets."""
     if pip_indices is None:
         return ()
+    if not validate_env_vars:
+        if isinstance(pip_indices, str):
+            return (pip_indices,)
+        return tuple(pip_indices)
     if isinstance(pip_indices, str):
         return _validate_pip_indices_env_vars((pip_indices,))
     return _validate_pip_indices_env_vars(pip_indices)
 
 
-def build_pip_index_arguments(pip_indices: Sequence[str]) -> list[str]:
+def build_pip_index_arguments(
+    pip_indices: Sequence[str],
+    *,
+    expand_env_vars: bool = True,
+) -> list[str]:
     """Build pip/uv index arguments from pip_indices list."""
     args = []
     if pip_indices:
-        expanded_indices = _expand_pip_indices_for_installer(pip_indices)
-        args.extend(["--index-url", expanded_indices[0]])
-        for index in expanded_indices[1:]:
+        indices = (
+            _expand_pip_indices_for_installer(pip_indices)
+            if expand_env_vars
+            else tuple(pip_indices)
+        )
+        args.extend(["--index-url", indices[0]])
+        for index in indices[1:]:
             args.extend(["--extra-index-url", index])
     return args
 


### PR DESCRIPTION
## Summary
- add `env_vars` command resolvers for install flows behind `--allow-env-commands`
- support `refresh: missing` and `refresh: always` while keeping installer command output redacted
- document YAML/TOML usage and add focused tests

## Tests
- `uv run --extra test pytest tests/test_env_vars.py tests/test_pip_indices.py tests/test_pip_index_redaction.py -q --no-cov`
- `uv run --extra test ruff check unidep/_env_vars.py tests/test_env_vars.py`
- `uv run --extra test ruff check --ignore UP036,PLC0415 unidep/_dependencies_parsing.py unidep/_cli.py`
- `git diff --check`
- `uv run --extra test python -m compileall -q unidep tests/test_env_vars.py`

Full `uv run --extra test pytest -q` is blocked locally by the existing Conda-environment precondition in install-command tests.

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--313.org.readthedocs.build/en/313/

<!-- readthedocs-preview unidep end -->