### PR TITLE
Fix ruff style for Python 3.9 baseline

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,12 +8,7 @@ from typing import TYPE_CHECKING
 from unidep._dependencies_parsing import yaml_to_toml
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from typing import Literal
 
 
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -155,9 +155,12 @@ dependencies:
   - cuda-toolkit  # [linux64]
 """,
     )
-    with patch("unidep._conda_lock._run_conda_lock", return_value=None), patch(
-        "unidep.utils.identify_current_platform",
-        return_value="osx-arm64",
+    with (
+        patch("unidep._conda_lock._run_conda_lock", return_value=None),
+        patch(
+            "unidep.utils.identify_current_platform",
+            return_value="osx-arm64",
+        ),
     ):
         conda_lock_command(
             depth=1,
@@ -332,9 +335,12 @@ def test_conda_lock_fails_before_lock_when_pip_index_env_var_is_unset(
 """,
     )
 
-    with patch("unidep._conda_lock._run_conda_lock") as run_conda_lock, pytest.raises(
-        ValueError,
-        match=r"PRIVATE_REPO_TOKEN.*pip_indices",
+    with (
+        patch("unidep._conda_lock._run_conda_lock") as run_conda_lock,
+        pytest.raises(
+            ValueError,
+            match=r"PRIVATE_REPO_TOKEN.*pip_indices",
+        ),
     ):
         conda_lock_command(
             depth=1,
@@ -648,13 +654,16 @@ def test_conda_lock_subpackages_skips_root_requirements(
             fp,
         )
 
-    with patch(
-        "unidep._conda_lock.find_requirements_files",
-        return_value=[root_req, sub_req],
-    ), patch(
-        "unidep._conda_lock._conda_lock_subpackage",
-        return_value=subdir / "conda-lock.yml",
-    ) as mock:
+    with (
+        patch(
+            "unidep._conda_lock.find_requirements_files",
+            return_value=[root_req, sub_req],
+        ),
+        patch(
+            "unidep._conda_lock._conda_lock_subpackage",
+            return_value=subdir / "conda-lock.yml",
+        ) as mock,
+    ):
         lock_files = _conda_lock_subpackages(tmp_path, 1, conda_lock_file)
 
     mock.assert_called_once()

--- a/tests/test_dependency_selection.py
+++ b/tests/test_dependency_selection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path, PureWindowsPath
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -59,7 +59,7 @@ def test_origin_to_text_normalizes_windows_style_local_chain() -> None:
         dependency_index=3,
         optional_group="dev",
         local_dependency_chain=cast(
-            Tuple[Path, ...],
+            "tuple[Path, ...]",
             (
                 PureWindowsPath("libs\\a"),
                 PureWindowsPath("libs\\b"),

--- a/tests/test_parse_yaml_local_dependencies.py
+++ b/tests/test_parse_yaml_local_dependencies.py
@@ -11,22 +11,13 @@ from typing import TYPE_CHECKING
 import pytest
 from ruamel.yaml import YAML
 
-from unidep import (
-    find_requirements_files,
-    parse_local_dependencies,
-    parse_requirements,
-)
+from unidep import find_requirements_files, parse_local_dependencies, parse_requirements
 from unidep._conflicts import resolve_conflicts
 
 from .helpers import maybe_as_toml
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from typing import Literal
 
 
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_parse_yaml_nested_local_dependencies.py
+++ b/tests/test_parse_yaml_nested_local_dependencies.py
@@ -8,20 +8,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from unidep import (
-    parse_local_dependencies,
-    parse_requirements,
-)
+from unidep import parse_local_dependencies, parse_requirements
 
 from .helpers import maybe_as_toml
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from typing import Literal
 
 
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_pip_index_redaction.py
+++ b/tests/test_pip_index_redaction.py
@@ -9,10 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from unidep._cli import _install_command, _pip_install_local
-from unidep._pip_indices import (
-    format_command_for_display,
-    redact_command_for_exception,
-)
+from unidep._pip_indices import format_command_for_display, redact_command_for_exception
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_pip_indices.py
+++ b/tests/test_pip_indices.py
@@ -10,10 +10,7 @@ import pytest
 import yaml
 
 from unidep._conda_env import CondaEnvironmentSpec, write_conda_environment_file
-from unidep._dependencies_parsing import (
-    _collect_pip_indices,
-    parse_requirements,
-)
+from unidep._dependencies_parsing import _collect_pip_indices, parse_requirements
 
 
 class TestPipIndicesParsing:

--- a/tests/test_pip_indices_integration.py
+++ b/tests/test_pip_indices_integration.py
@@ -124,9 +124,12 @@ class TestUnidepInstallIntegration:
     def test_install_with_uv_backend(self, mock_project: Path) -> None:  # noqa: ARG002
         """Test that pip_indices work with uv backend."""
         # uv uses the same --index-url and --extra-index-url flags
-        with patch("shutil.which", return_value="/path/to/uv"), patch(
-            "subprocess.run",
-        ) as mock_run:
+        with (
+            patch("shutil.which", return_value="/path/to/uv"),
+            patch(
+                "subprocess.run",
+            ) as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
 
             # Expected uv command structure

--- a/tests/test_project_dependency_handling.py
+++ b/tests/test_project_dependency_handling.py
@@ -7,10 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 import pytest
 
-from unidep._dependencies_parsing import (
-    _add_project_dependencies,
-    parse_requirements,
-)
+from unidep._dependencies_parsing import _add_project_dependencies, parse_requirements
 from unidep.platform_definitions import Spec
 
 if TYPE_CHECKING:

--- a/tests/test_pypi_alternatives.py
+++ b/tests/test_pypi_alternatives.py
@@ -27,11 +27,7 @@ else:  # pragma: no cover
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from typing import Literal
 
 
 def test_parse_local_dependency_item_string() -> None:

--- a/tests/test_python_support_policy.py
+++ b/tests/test_python_support_policy.py
@@ -48,9 +48,7 @@ def test_ci_matrices_start_at_python_39() -> None:
         == SUPPORTED_PYTHON_VERSIONS
     )
     assert (
-        install_workflow["jobs"]["pip-install"]["strategy"]["matrix"][
-            "python-version"
-        ]
+        install_workflow["jobs"]["pip-install"]["strategy"]["matrix"]["python-version"]
         == SUPPORTED_PYTHON_VERSIONS
     )
     assert (
@@ -59,9 +57,6 @@ def test_ci_matrices_start_at_python_39() -> None:
         ]
         == SUPPORTED_PYTHON_VERSIONS
     )
-    assert (
-        install_workflow["jobs"]["miniconda-install"]["strategy"]["matrix"][
-            "python-version"
-        ]
-        == ["3.9", "3.12"]
-    )
+    assert install_workflow["jobs"]["miniconda-install"]["strategy"]["matrix"][
+        "python-version"
+    ] == ["3.9", "3.12"]

--- a/tests/test_setuptools_integration.py
+++ b/tests/test_setuptools_integration.py
@@ -127,10 +127,13 @@ def test_package_name_from_path_does_not_suppress_unexpected_errors(
     setup_py = tmp_path / "setup.py"
     setup_py.write_text("from setuptools import setup\nsetup(name='pkg')")
 
-    with patch(
-        "unidep.utils.package_name_from_setup_py",
-        side_effect=RuntimeError("boom"),
-    ), pytest.raises(RuntimeError, match="boom"):
+    with (
+        patch(
+            "unidep.utils.package_name_from_setup_py",
+            side_effect=RuntimeError("boom"),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
         package_name_from_path(tmp_path)
 
 

--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -31,14 +31,9 @@ from unidep.utils import is_pip_installable
 from .helpers import maybe_as_toml
 
 if TYPE_CHECKING:
-    import sys
+    from typing import Literal
 
     from unidep.platform_definitions import CondaPip
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
 
 
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import importlib.metadata
-import sys
 from pathlib import Path
+from typing import get_args
 from unittest.mock import patch
 
 import pytest
@@ -23,11 +23,6 @@ from unidep.utils import (
     resolve_platforms,
     split_path_and_extras,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import get_args
-else:  # pragma: no cover
-    from typing_extensions import get_args
 
 
 def test_escape_unicode() -> None:
@@ -75,67 +70,101 @@ def test_spec_rendering_helpers() -> None:
 
 
 def test_detect_platform() -> None:
-    with patch("platform.system", return_value="Linux"), patch(
-        "platform.machine",
-        return_value="x86_64",
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "platform.machine",
+            return_value="x86_64",
+        ),
     ):
         assert identify_current_platform() == "linux-64"
 
-    with patch("platform.system", return_value="Linux"), patch(
-        "platform.machine",
-        return_value="aarch64",
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "platform.machine",
+            return_value="aarch64",
+        ),
     ):
         assert identify_current_platform() == "linux-aarch64"
 
-    with patch("platform.system", return_value="Darwin"), patch(
-        "platform.machine",
-        return_value="x86_64",
+    with (
+        patch("platform.system", return_value="Darwin"),
+        patch(
+            "platform.machine",
+            return_value="x86_64",
+        ),
     ):
         assert identify_current_platform() == "osx-64"
 
-    with patch("platform.system", return_value="Darwin"), patch(
-        "platform.machine",
-        return_value="arm64",
+    with (
+        patch("platform.system", return_value="Darwin"),
+        patch(
+            "platform.machine",
+            return_value="arm64",
+        ),
     ):
         assert identify_current_platform() == "osx-arm64"
 
-    with patch("platform.system", return_value="Windows"), patch(
-        "platform.machine",
-        return_value="AMD64",
+    with (
+        patch("platform.system", return_value="Windows"),
+        patch(
+            "platform.machine",
+            return_value="AMD64",
+        ),
     ):
         assert identify_current_platform() == "win-64"
 
-    with patch("platform.system", return_value="Linux"), patch(
-        "platform.machine",
-        return_value="unknown",
-    ), pytest.raises(UnsupportedPlatformError, match="Unsupported Linux architecture"):
-        identify_current_platform()
-
-    with patch("platform.system", return_value="Darwin"), patch(
-        "platform.machine",
-        return_value="unknown",
-    ), pytest.raises(UnsupportedPlatformError, match="Unsupported macOS architecture"):
-        identify_current_platform()
-
-    with patch("platform.system", return_value="Windows"), patch(
-        "platform.machine",
-        return_value="unknown",
-    ), pytest.raises(
-        UnsupportedPlatformError,
-        match="Unsupported Windows architecture",
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "platform.machine",
+            return_value="unknown",
+        ),
+        pytest.raises(UnsupportedPlatformError, match="Unsupported Linux architecture"),
     ):
         identify_current_platform()
 
-    with patch("platform.system", return_value="Linux"), patch(
-        "platform.machine",
-        return_value="ppc64le",
+    with (
+        patch("platform.system", return_value="Darwin"),
+        patch(
+            "platform.machine",
+            return_value="unknown",
+        ),
+        pytest.raises(UnsupportedPlatformError, match="Unsupported macOS architecture"),
+    ):
+        identify_current_platform()
+
+    with (
+        patch("platform.system", return_value="Windows"),
+        patch(
+            "platform.machine",
+            return_value="unknown",
+        ),
+        pytest.raises(
+            UnsupportedPlatformError,
+            match="Unsupported Windows architecture",
+        ),
+    ):
+        identify_current_platform()
+
+    with (
+        patch("platform.system", return_value="Linux"),
+        patch(
+            "platform.machine",
+            return_value="ppc64le",
+        ),
     ):
         assert identify_current_platform() == "linux-ppc64le"
 
-    with patch("platform.system", return_value="Unknown"), patch(
-        "platform.machine",
-        return_value="x86_64",
-    ), pytest.raises(UnsupportedPlatformError, match="Unsupported operating system"):
+    with (
+        patch("platform.system", return_value="Unknown"),
+        patch(
+            "platform.machine",
+            return_value="x86_64",
+        ),
+        pytest.raises(UnsupportedPlatformError, match="Unsupported operating system"),
+    ):
         identify_current_platform()
 
 

--- a/unidep/_conda_env.py
+++ b/unidep/_conda_env.py
@@ -28,10 +28,7 @@ from unidep.platform_definitions import (
     Platform,
     Spec,
 )
-from unidep.utils import (
-    add_comment_to_file,
-    build_pep508_environment_marker,
-)
+from unidep.utils import add_comment_to_file, build_pep508_environment_marker
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -39,10 +36,7 @@ if TYPE_CHECKING:
 
     from unidep._dependencies_parsing import DependencyEntry
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, get_args
-else:  # pragma: no cover
-    from typing_extensions import Literal, get_args
+from typing import Literal, get_args
 
 
 class CondaEnvironmentSpec(NamedTuple):

--- a/unidep/_conda_lock.py
+++ b/unidep/_conda_lock.py
@@ -23,19 +23,12 @@ from unidep._dependency_selection import (
     collapse_selected_universals,
     select_conda_like_requirements,
 )
-from unidep.utils import (
-    add_comment_to_file,
-    remove_top_comments,
-    warn,
-)
+from unidep.utils import add_comment_to_file, remove_top_comments, warn
 
 if TYPE_CHECKING:
-    from unidep.platform_definitions import CondaPip, Platform
+    from typing import Literal
 
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from unidep.platform_definitions import CondaPip, Platform
 
 
 def _run_conda_lock(
@@ -429,7 +422,7 @@ def _conda_lock_subpackage(
     yaml.representer.ignore_aliases = lambda *_: True  # Disable anchors
     conda_lock_output = file.parent / "conda-lock.yml"
     metadata = {
-        "content_hash": {p: "unidep-is-awesome" for p in platforms},
+        "content_hash": dict.fromkeys(platforms, "unidep-is-awesome"),
         "channels": [{"url": c, "used_env_vars": []} for c in channels],
         "platforms": platforms,
         "sources": [str(file)],

--- a/unidep/_conflicts.py
+++ b/unidep/_conflicts.py
@@ -5,20 +5,13 @@ Verion conflict detections and resolution.
 
 from __future__ import annotations
 
-import sys
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
 
 from packaging import version
 
 from unidep.platform_definitions import Platform, Spec
 from unidep.utils import defaultdict_to_dict
-
-if sys.version_info >= (3, 8):
-    from typing import get_args
-else:  # pragma: no cover
-    from typing_extensions import get_args
-
 
 if TYPE_CHECKING:
     from unidep.platform_definitions import CondaPip

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -36,10 +36,7 @@ from unidep.utils import (
 )
 
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:  # pragma: no cover
-        from typing_extensions import Literal
+    from typing import Literal
 
 
 if sys.version_info >= (3, 11):

--- a/unidep/_dependency_selection.py
+++ b/unidep/_dependency_selection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from packaging.specifiers import InvalidSpecifier, Specifier
 from packaging.utils import canonicalize_name
@@ -15,12 +15,7 @@ from unidep._conflicts import (
     combine_version_pinnings,
     extract_version_operator,
 )
-from unidep.platform_definitions import (
-    PLATFORM_SELECTOR_MAP,
-    CondaPip,
-    Platform,
-    Spec,
-)
+from unidep.platform_definitions import PLATFORM_SELECTOR_MAP, CondaPip, Platform, Spec
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -28,7 +23,7 @@ if TYPE_CHECKING:
     from unidep._dependencies_parsing import DependencyEntry, DependencyOrigin
 
 TargetPlatform = Optional[Platform]
-FamilyKey = Tuple[Optional[str], Optional[str]]
+FamilyKey = tuple[Optional[str], Optional[str]]
 
 
 @dataclass(frozen=True)

--- a/unidep/_doctor.py
+++ b/unidep/_doctor.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAML
 
@@ -21,6 +21,9 @@ from unidep._dependencies_parsing import (
     get_local_dependencies,
 )
 from unidep.utils import split_path_and_extras
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 CONDA_DISTRIBUTIONS = {
     "anaconda": ("anaconda3", "anaconda"),

--- a/unidep/_hatch_integration.py
+++ b/unidep/_hatch_integration.py
@@ -11,9 +11,7 @@ from hatchling.metadata.plugin.interface import MetadataHookInterface
 from hatchling.plugin import hookimpl
 
 from unidep._setuptools_integration import _deps
-from unidep.utils import (
-    parse_folder_or_filename,
-)
+from unidep.utils import parse_folder_or_filename
 
 __all__ = ["UnidepRequirementsMetadataHook"]
 

--- a/unidep/_pixi.py
+++ b/unidep/_pixi.py
@@ -7,16 +7,9 @@ import os
 import re
 import sys
 from collections import Counter, deque
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    NamedTuple,
-    Sequence,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 from ruamel.yaml import YAML
 
@@ -43,7 +36,7 @@ from unidep.utils import (
 )
 
 if TYPE_CHECKING:
-    from typing import Dict, Optional, Tuple, Union
+    from typing import Optional, Union
 
     from unidep._dependencies_parsing import ParsedRequirements
     from unidep.platform_definitions import Spec
@@ -56,13 +49,13 @@ if TYPE_CHECKING:
     from unidep.platform_definitions import Platform
 
     # Version spec can be a string or dict with version/build/extras
-    VersionSpec: TypeAlias = Union[str, Dict[str, Any]]
+    VersionSpec: TypeAlias = Union[str, dict[str, Any]]
 
     # Type alias for the extracted dependencies structure
     # Maps platform (or None for universal) to (conda_deps, pip_deps)
-    PlatformDeps: TypeAlias = Dict[
+    PlatformDeps: TypeAlias = dict[
         Optional[str],
-        Tuple[Dict[str, VersionSpec], Dict[str, VersionSpec]],
+        tuple[dict[str, VersionSpec], dict[str, VersionSpec]],
     ]
 
 

--- a/unidep/_setuptools_integration.py
+++ b/unidep/_setuptools_integration.py
@@ -34,16 +34,11 @@ from unidep.utils import (
 )
 
 if TYPE_CHECKING:
-    import sys
+    from typing import Literal
 
     from setuptools import Distribution
 
     from unidep.platform_definitions import Platform, Spec
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 def filter_python_dependencies(

--- a/unidep/platform_definitions.py
+++ b/unidep/platform_definitions.py
@@ -5,14 +5,7 @@ Types and definitions for platforms, selectors, and markers.
 
 from __future__ import annotations
 
-import sys
-from typing import NamedTuple, cast
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, get_args
-else:  # pragma: no cover
-    from typing_extensions import Literal, get_args
-
+from typing import Literal, NamedTuple, cast, get_args
 
 CondaPlatform = Literal["unix", "linux", "osx", "win"]
 Platform = Literal[

--- a/unidep/utils.py
+++ b/unidep/utils.py
@@ -492,19 +492,9 @@ def get_package_version(package_name: str) -> str | None:
     The version of the package, or None if the package is not found.
 
     """
-    if sys.version_info >= (3, 8):
-        import importlib.metadata
+    import importlib.metadata
 
-        try:
-            return importlib.metadata.version(package_name)
-        except importlib.metadata.PackageNotFoundError:
-            return None
-    else:  # pragma: no cover
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            import pkg_resources
-
-        try:
-            return pkg_resources.get_distribution(package_name).version
-        except pkg_resources.DistributionNotFound:
-            return None
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None


### PR DESCRIPTION
## Summary
- Remove dead Python <3.9 import fallbacks now that the project requires Python 3.9+
- Update deprecated typing aliases and type-only imports flagged by ruff
- Include current formatter style changes in touched tests and modules

## Verification
- pre-commit run --all-files
- uv run --extra test pytest -q tests (704 passed)

<!-- readthedocs-preview unidep start -->
----
📚 Documentation preview 📚: https://unidep--314.org.readthedocs.build/en/314/

<!-- readthedocs-preview unidep end -->